### PR TITLE
Deploy docs to repo

### DIFF
--- a/.github/workflows/yard.yml
+++ b/.github/workflows/yard.yml
@@ -1,0 +1,29 @@
+name: yard
+
+on: [push]
+
+permissions:
+  id-token: write
+  pages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - run: bundle exec yard doc
+      - name: Commit files
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          
+          git add -A
+          git commit -m "Update documentation [skip ci]"
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}

--- a/content_block_tools.gemspec
+++ b/content_block_tools.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "13.2.1"
   spec.add_development_dependency "rspec", "3.13.0"
   spec.add_development_dependency "rubocop-govuk", "5.0.2"
+  spec.add_development_dependency "yard", "0.9.37"
 
   spec.add_dependency "actionview", ">= 6", "< 7.2.2"
 end


### PR DESCRIPTION
This builds the documentation using [Yard](https://github.com/lsegal/yard) and pushes it to the `docs` directory. It will then get hosted in the developer docs once we add it (e.g https://docs.publishing.service.gov.uk/repos/gds-sso.html)