### PR TITLE
Loosen Actionview dependency further

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 0.3.1
+
+* Support any Rails version `>= 6` ([#10](https://github.com/alphagov/govuk_content_block_tools/pull/10))
+
 ## 0.3.0
 
 * Symbolise details hash ([#8](https://github.com/alphagov/content_block_tools/pull/8))

--- a/content_block_tools.gemspec
+++ b/content_block_tools.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "3.13.0"
   spec.add_development_dependency "rubocop-govuk", "5.0.2"
 
-  spec.add_dependency "actionview", ">= 6", "< 7.2.2"
+  spec.add_dependency "actionview", ">= 6"
 end

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
We probably don’t need to be so prescriptive. If an app is running any Rails version `>= 6`, we should be OK to support it.
