### PR TITLE
Specify gem name

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -6,5 +6,7 @@ on:
 jobs:
   autorelease:
     uses: alphagov/govuk-infrastructure/.github/workflows/autorelease-rubygem.yml@main
+    with:
+      gem_name: content_block_tools
     secrets:
       GH_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,5 +40,7 @@ jobs:
     permissions:
       contents: write
     uses: alphagov/govuk-infrastructure/.github/workflows/publish-rubygem.yml@main
+    with:
+      gem_name: content_block_tools
     secrets:
       GEM_HOST_API_KEY: ${{ secrets.ALPHAGOV_RUBYGEMS_API_KEY }}


### PR DESCRIPTION
We’ve recently renamed the repo to be more in line with naming conventions, but not the gem (as this would open up a bit of a can of worms, as there’s no real support in Rubygems for renaming). As a result, we need to specify the gem name in the Github actions, as they default to using the repo name, and both the release and autorelease jobs are failing at the mo