### PR TITLE
content modelling/865 fields in embed codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 0.4.0
+
+* BREAKING: allow support for field names in block's embed code. new ContentBlocks now require an embed code argument. (
+  [17]
+  (https://github.com/alphagov/govuk_content_block_tools/pull/17))
+
 ## 0.3.1
 
 * Support any Rails version `>= 6` ([#10](https://github.com/alphagov/govuk_content_block_tools/pull/10))

--- a/lib/content_block_tools.rb
+++ b/lib/content_block_tools.rb
@@ -5,6 +5,7 @@ require "uri"
 
 require "content_block_tools/presenters/base_presenter"
 require "content_block_tools/presenters/email_address_presenter"
+require "content_block_tools/presenters/postal_address_presenter"
 
 require "content_block_tools/content_block"
 require "content_block_tools/content_block_reference"

--- a/lib/content_block_tools/content_block.rb
+++ b/lib/content_block_tools/content_block.rb
@@ -44,6 +44,7 @@ module ContentBlockTools
     # A lookup of presenters for particular content block types
     CONTENT_PRESENTERS = {
       "content_block_email_address" => ContentBlockTools::Presenters::EmailAddressPresenter,
+      "content_block_postal_address" => ContentBlockTools::Presenters::PostalAddressPresenter,
     }.freeze
 
     # Calls the appropriate presenter class to return a HTML representation of a content

--- a/lib/content_block_tools/content_block.rb
+++ b/lib/content_block_tools/content_block.rb
@@ -1,5 +1,5 @@
 module ContentBlockTools
-  ContentBlock = Data.define(:content_id, :title, :document_type, :details)
+  ContentBlock = Data.define(:content_id, :title, :document_type, :details, :embed_code)
 
   # Defines a Content Block
   #
@@ -33,6 +33,13 @@ module ContentBlockTools
   #   content_block.details #=> { email_address: "foo@example.com" }
   #  @return [Hash] the details
   #  @api public
+  #
+  # @!attribute [r] embed_code
+  #  The embed_code used for a block containing optional field name
+  #   @example
+  #     content_block_reference.embed_code #=> "{{embed:content_block_email_address:2b92cade-549c-4449-9796-e7a3957f3a86}}"
+  #     content_block_reference.embed_code #=> "{{embed:content_block_postal_address:2b92cade-549c-4449-9796-e7a3957f3a86/field_name}}"
+  #   @return [String]
   class ContentBlock < Data
     # A lookup of presenters for particular content block types
     CONTENT_PRESENTERS = {

--- a/lib/content_block_tools/content_block_reference.rb
+++ b/lib/content_block_tools/content_block_reference.rb
@@ -26,11 +26,13 @@ module ContentBlockTools
   #   @return [String]
   class ContentBlockReference < Data
     # An array of the supported document types
-    SUPPORTED_DOCUMENT_TYPES = %w[contact content_block_email_address].freeze
+    SUPPORTED_DOCUMENT_TYPES = %w[contact content_block_email_address content_block_postal_address].freeze
     # The regex used to find UUIDs
     UUID_REGEX = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/
+    # The regex to find optional field names after the UUID, begins with '/'
+    FIELD_REGEX = /(\/.*)?/
     # The regex used when scanning a document using {ContentBlockTools::ContentBlockReference.find_all_in_document}
-    EMBED_REGEX = /({{embed:(#{SUPPORTED_DOCUMENT_TYPES.join('|')}):#{UUID_REGEX}}})/
+    EMBED_REGEX = /({{embed:(#{SUPPORTED_DOCUMENT_TYPES.join('|')}):#{UUID_REGEX}#{FIELD_REGEX}}})/
 
     class << self
       # Finds all content block references within a document, using `ContentBlockReference::EMBED_REGEX`

--- a/lib/content_block_tools/presenters/base_presenter.rb
+++ b/lib/content_block_tools/presenters/base_presenter.rb
@@ -29,11 +29,14 @@ module ContentBlockTools
             content_block: "",
             document_type: content_block.document_type,
             content_id: content_block.content_id,
+            field_names: field_names&.join(","),
           },
         )
       end
 
     private
+
+      attr_reader :content_block
 
       # The default representation of the content block - this can be overridden in a subclass
       # by overriding the content, default_content or content_for_fields methods
@@ -57,14 +60,12 @@ module ContentBlockTools
       end
 
       def field_names
-        embed_code_match = ContentBlockReference::EMBED_REGEX.match(@content_block.embed_code)
+        embed_code_match = ContentBlockReference::EMBED_REGEX.match(content_block.embed_code)
         if embed_code_match.present?
           all_fields = embed_code_match[4]&.reverse&.chomp("/")&.reverse
           all_fields&.split("/")&.map(&:to_sym)
         end
       end
-
-      attr_reader :content_block
     end
   end
 end

--- a/lib/content_block_tools/presenters/base_presenter.rb
+++ b/lib/content_block_tools/presenters/base_presenter.rb
@@ -36,11 +36,32 @@ module ContentBlockTools
     private
 
       # The default representation of the content block - this can be overridden in a subclass
+      # by overriding the content, default_content or content_for_fields methods
       #
       # @return [string] A representation of the content block to be wrapped in the base_tag in
       # {#content}
       def content
+        if field_names.present?
+          content_for_fields
+        else
+          default_content
+        end
+      end
+
+      def default_content
         content_block.title
+      end
+
+      def content_for_fields
+        content_block.details.dig(*field_names)
+      end
+
+      def field_names
+        embed_code_match = ContentBlockReference::EMBED_REGEX.match(@content_block.embed_code)
+        if embed_code_match.present?
+          all_fields = embed_code_match[4]&.reverse&.chomp("/")&.reverse
+          all_fields&.split("/")&.map(&:to_sym)
+        end
       end
 
       attr_reader :content_block

--- a/lib/content_block_tools/presenters/postal_address_presenter.rb
+++ b/lib/content_block_tools/presenters/postal_address_presenter.rb
@@ -1,0 +1,11 @@
+module ContentBlockTools
+  module Presenters
+    class PostalAddressPresenter < BasePresenter
+    private
+
+      def default_content
+        "#{content_block.details[:line_1]}, #{content_block.details[:town_or_city]}, #{content_block.details[:postcode]}"
+      end
+    end
+  end
+end

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end

--- a/spec/content_block_tools/content_block_reference_spec.rb
+++ b/spec/content_block_tools/content_block_reference_spec.rb
@@ -67,6 +67,30 @@ RSpec.describe ContentBlockTools::ContentBlockReference do
             expect(result[2].content_id).to eq(content_block_email_address_uuid)
           end
         end
+
+        context "when there are fields in the embed code" do
+          let(:contact_uuid) { SecureRandom.uuid }
+          let(:content_block_email_address_uuid) { SecureRandom.uuid }
+
+          let(:document) do
+            "
+              {{embed:contact:#{contact_uuid}/example_field}}
+              {{embed:content_block_email_address:#{content_block_email_address_uuid}/another_field}}
+            "
+          end
+
+          it "finds all the references" do
+            expect(result.count).to eq(2)
+
+            expect(result[0].document_type).to eq("contact")
+            expect(result[0].content_id).to eq(contact_uuid)
+            expect(result[0].embed_code).to eq("{{embed:contact:#{contact_uuid}/example_field}}")
+
+            expect(result[1].document_type).to eq("content_block_email_address")
+            expect(result[1].content_id).to eq(content_block_email_address_uuid)
+            expect(result[1].embed_code).to eq("{{embed:content_block_email_address:#{content_block_email_address_uuid}/another_field}}")
+          end
+        end
       end
     end
   end

--- a/spec/content_block_tools/content_block_spec.rb
+++ b/spec/content_block_tools/content_block_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe ContentBlockTools::ContentBlock do
   let(:title) { "Some Title" }
   let(:document_type) { "content_block_email_address" }
   let(:details) { { some: "details" } }
+  let(:embed_code) { "something" }
 
   let(:content_block) do
     described_class.new(
@@ -10,6 +11,7 @@ RSpec.describe ContentBlockTools::ContentBlock do
       content_id:,
       title:,
       details:,
+      embed_code:,
     )
   end
 

--- a/spec/content_block_tools/presenters/base_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/base_presenter_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe ContentBlockTools::Presenters::BasePresenter do
       content_id:,
       title: "My content block",
       details: {},
+      embed_code: "something",
     )
   end
 

--- a/spec/content_block_tools/presenters/base_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/base_presenter_spec.rb
@@ -23,4 +23,58 @@ RSpec.describe ContentBlockTools::Presenters::BasePresenter do
 
     expect(presenter.render.squish).to eq(expected_html.squish)
   end
+
+  it "should render nested fields" do
+    content_block_with_nested_fields = ContentBlockTools::ContentBlock.new(
+      document_type: "something",
+      content_id:,
+      title: "My content block",
+      details: {
+        first_field: {
+          second_field: {
+            third_field: "hello world",
+          },
+        },
+      },
+      embed_code: "{{embed:content_block_postal_address:#{content_id}/first_field/second_field/third_field}}",
+    )
+
+    presenter = described_class.new(content_block_with_nested_fields)
+    expected_html = <<-HTML
+      <span
+        class="content-embed content-embed__something"
+        data-content-block=""
+        data-document-type="something"
+        data-content-id="#{content_id}">hello world</span>
+    HTML
+
+    expect(presenter.render.squish).to eq(expected_html.squish)
+  end
+
+  it "should return empty string if a given field does not exist" do
+    content_block_with_nested_fields = ContentBlockTools::ContentBlock.new(
+      document_type: "something",
+      content_id:,
+      title: "My content block",
+      details: {
+        first_field: {
+          second_field: {
+            third_field: "hello world",
+          },
+        },
+      },
+      embed_code: "{{embed:content_block_postal_address:#{content_id}/first_field/second_field/fake_field}}",
+    )
+
+    presenter = described_class.new(content_block_with_nested_fields)
+    expected_html = <<-HTML
+      <span
+        class="content-embed content-embed__something"
+        data-content-block=""
+        data-document-type="something"
+        data-content-id="#{content_id}"></span>
+    HTML
+
+    expect(presenter.render.squish).to eq(expected_html.squish)
+  end
 end

--- a/spec/content_block_tools/presenters/base_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/base_presenter_spec.rb
@@ -45,7 +45,8 @@ RSpec.describe ContentBlockTools::Presenters::BasePresenter do
         class="content-embed content-embed__something"
         data-content-block=""
         data-document-type="something"
-        data-content-id="#{content_id}">hello world</span>
+        data-content-id="#{content_id}"
+        data-field-names="first_field,second_field,third_field">hello world</span>
     HTML
 
     expect(presenter.render.squish).to eq(expected_html.squish)
@@ -72,7 +73,8 @@ RSpec.describe ContentBlockTools::Presenters::BasePresenter do
         class="content-embed content-embed__something"
         data-content-block=""
         data-document-type="something"
-        data-content-id="#{content_id}"></span>
+        data-content-id="#{content_id}"
+        data-field-names="first_field,second_field,fake_field"></span>
     HTML
 
     expect(presenter.render.squish).to eq(expected_html.squish)

--- a/spec/content_block_tools/presenters/email_address_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/email_address_presenter_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe ContentBlockTools::Presenters::EmailAddressPresenter do
       content_id:,
       title: "My content block",
       details: { email_address: },
+      embed_code: "something",
     )
   end
 

--- a/spec/content_block_tools/presenters/postal_address_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/postal_address_presenter_spec.rb
@@ -1,0 +1,85 @@
+RSpec.describe ContentBlockTools::Presenters::PostalAddressPresenter do
+  let(:content_id) { SecureRandom.uuid }
+  let(:postal_address) do
+    {
+      line_1: "1 street",
+      town_or_city: "Somewhereville",
+      postcode: "ABC 123",
+    }
+  end
+
+  let(:postal_html_string) do
+    "1 street, Somewhereville, ABC 123"
+  end
+
+  let(:content_block) do
+    ContentBlockTools::ContentBlock.new(
+      document_type: "something",
+      content_id:,
+      title: "My postal content block",
+      details: { **postal_address },
+      embed_code: "{{embed:content_block_postal_address:#{content_id}}}",
+    )
+  end
+
+  it "should render with the postal address" do
+    presenter = described_class.new(content_block)
+    expected_html = <<-HTML
+      <span
+        class="content-embed content-embed__something"
+        data-content-block=""
+        data-document-type="something"
+        data-content-id="#{content_id}">#{postal_html_string}</span>
+    HTML
+
+    expect(presenter.render.squish).to eq(expected_html.squish)
+  end
+
+  context "when fields have been defined" do
+    let(:content_block_with_fields) do
+      ContentBlockTools::ContentBlock.new(
+        document_type: "something",
+        content_id:,
+        title: "My postal content block",
+        details: { **postal_address },
+        embed_code: "{{embed:content_block_postal_address:#{content_id}/town_or_city}}",
+      )
+    end
+
+    let(:content_block_with_fake_fields) do
+      ContentBlockTools::ContentBlock.new(
+        document_type: "something",
+        content_id:,
+        title: "My postal content block",
+        details: { **postal_address },
+        embed_code: "{{embed:content_block_postal_address:#{content_id}/nothing}}",
+      )
+    end
+
+    it "should render only the value of that field" do
+      presenter = described_class.new(content_block_with_fields)
+      expected_html = <<-HTML
+      <span
+        class="content-embed content-embed__something"
+        data-content-block=""
+        data-document-type="something"
+        data-content-id="#{content_id}">Somewhereville</span>
+      HTML
+
+      expect(presenter.render.squish).to eq(expected_html.squish)
+    end
+
+    it "should return empty string if given a fake field" do
+      presenter = described_class.new(content_block_with_fake_fields)
+      expected_html = <<-HTML
+      <span
+        class="content-embed content-embed__something"
+        data-content-block=""
+        data-document-type="something"
+        data-content-id="#{content_id}"></span>
+      HTML
+
+      expect(presenter.render.squish).to eq(expected_html.squish)
+    end
+  end
+end

--- a/spec/content_block_tools/presenters/postal_address_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/postal_address_presenter_spec.rb
@@ -63,7 +63,8 @@ RSpec.describe ContentBlockTools::Presenters::PostalAddressPresenter do
         class="content-embed content-embed__something"
         data-content-block=""
         data-document-type="something"
-        data-content-id="#{content_id}">Somewhereville</span>
+        data-content-id="#{content_id}"
+        data-field-names="town_or_city">Somewhereville</span>
       HTML
 
       expect(presenter.render.squish).to eq(expected_html.squish)
@@ -76,7 +77,8 @@ RSpec.describe ContentBlockTools::Presenters::PostalAddressPresenter do
         class="content-embed content-embed__something"
         data-content-block=""
         data-document-type="something"
-        data-content-id="#{content_id}"></span>
+        data-content-id="#{content_id}"
+        data-field-names="nothing"></span>
       HTML
 
       expect(presenter.render.squish).to eq(expected_html.squish)


### PR DESCRIPTION
https://trello.com/c/UWUx0rCF/865-allow-individual-fields-to-be-embedded-with-embed-code 

We want to enable users to pass field names via a Content Blocks embed code, like this:

`{{embed:content_block_email_address:2593f06c-b7c8-4173-9a47-09d9bdd767ef/field_name/another_field}}`

The field names currently can only be keys within a block's `details` json blob.

This PR introduces:
1. requiring the `embed_code` to be passed to a ContentBlock when presenting it, because we now need to know the content of the code to determine whether a field is required.
2. changing the regex match used to find an embed code to include an optional substring containing field names.

I'm using the test type of postal address so we can see it working IRL.

## next steps:  

1. The breaking changes are fixed in Publishing API here to show how the embed code can be retrieved and then passed in https://github.com/alphagov/publishing-api/pull/3117 
3. If we are happy with this approach, we should introduce some error handling and throw Sentry errors if an incorrect field name is used so we can track how often/if that happens.

---

This repo is owned by the content modelling team. Please let us know in #govuk-publishing-content-modelling-dev when you raise any PRs.
