### PR TITLE
content modelling/881 add embed code data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 0.4.2
+
+* Pass embed code to HTML span ([19](https://github.com/alphagov/govuk_content_block_tools/pull/19))
+
 ## 0.4.1
 
 * Fix field regular expression ([18](https://github.com/alphagov/govuk_content_block_tools/pull/18))

--- a/lib/content_block_tools/presenters/base_presenter.rb
+++ b/lib/content_block_tools/presenters/base_presenter.rb
@@ -29,7 +29,7 @@ module ContentBlockTools
             content_block: "",
             document_type: content_block.document_type,
             content_id: content_block.content_id,
-            field_names: field_names&.join(","),
+            embed_code: content_block.embed_code,
           },
         )
       end

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
 end

--- a/spec/content_block_tools/presenters/base_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/base_presenter_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe ContentBlockTools::Presenters::BasePresenter do
         class="content-embed content-embed__something"
         data-content-block=""
         data-document-type="something"
-        data-content-id="#{content_id}">My content block</span>
+        data-content-id="#{content_id}"
+        data-embed-code="something">My content block</span>
     HTML
 
     expect(presenter.render.squish).to eq(expected_html.squish)
@@ -46,7 +47,7 @@ RSpec.describe ContentBlockTools::Presenters::BasePresenter do
         data-content-block=""
         data-document-type="something"
         data-content-id="#{content_id}"
-        data-field-names="first_field,second_field,third_field">hello world</span>
+        data-embed-code="{{embed:content_block_postal_address:#{content_id}/first_field/second_field/third_field}}">hello world</span>
     HTML
 
     expect(presenter.render.squish).to eq(expected_html.squish)
@@ -74,7 +75,7 @@ RSpec.describe ContentBlockTools::Presenters::BasePresenter do
         data-content-block=""
         data-document-type="something"
         data-content-id="#{content_id}"
-        data-field-names="first_field,second_field,fake_field"></span>
+        data-embed-code="{{embed:content_block_postal_address:#{content_id}/first_field/second_field/fake_field}}"></span>
     HTML
 
     expect(presenter.render.squish).to eq(expected_html.squish)

--- a/spec/content_block_tools/presenters/email_address_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/email_address_presenter_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe ContentBlockTools::Presenters::EmailAddressPresenter do
         class="content-embed content-embed__something"
         data-content-block=""
         data-document-type="something"
-        data-content-id="#{content_id}">#{email_address}</span>
+        data-content-id="#{content_id}"
+        data-embed-code="something">#{email_address}</span>
     HTML
 
     expect(presenter.render.squish).to eq(expected_html.squish)

--- a/spec/content_block_tools/presenters/postal_address_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/postal_address_presenter_spec.rb
@@ -29,7 +29,8 @@ RSpec.describe ContentBlockTools::Presenters::PostalAddressPresenter do
         class="content-embed content-embed__something"
         data-content-block=""
         data-document-type="something"
-        data-content-id="#{content_id}">#{postal_html_string}</span>
+        data-content-id="#{content_id}"
+        data-embed-code="{{embed:content_block_postal_address:#{content_id}}}">#{postal_html_string}</span>
     HTML
 
     expect(presenter.render.squish).to eq(expected_html.squish)
@@ -64,7 +65,7 @@ RSpec.describe ContentBlockTools::Presenters::PostalAddressPresenter do
         data-content-block=""
         data-document-type="something"
         data-content-id="#{content_id}"
-        data-field-names="town_or_city">Somewhereville</span>
+        data-embed-code="{{embed:content_block_postal_address:#{content_id}/town_or_city}}">Somewhereville</span>
       HTML
 
       expect(presenter.render.squish).to eq(expected_html.squish)
@@ -78,7 +79,7 @@ RSpec.describe ContentBlockTools::Presenters::PostalAddressPresenter do
         data-content-block=""
         data-document-type="something"
         data-content-id="#{content_id}"
-        data-field-names="nothing"></span>
+        data-embed-code="{{embed:content_block_postal_address:#{content_id}/nothing}}"></span>
       HTML
 
       expect(presenter.render.squish).to eq(expected_html.squish)


### PR DESCRIPTION
- **pass entire embed code to html of block**
- **bump version**

This will allow the logic in the `generate_preview` service in Content Block Manager to grab the embed code from the HTML preview and pass it back to Tools to work out what should be rendered.

----
This repo is owned by the content modelling team. Please let us know in #govuk-publishing-content-modelling-dev when you raise any PRs.
