### PR TITLE
content modelling/880 add pension presenter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 0.4.3
+
+* Add presenter for a pension block ([20](https://github.com/alphagov/govuk_content_block_tools/pull/20))
+
 ## 0.4.2
 
 * Pass embed code to HTML span ([19](https://github.com/alphagov/govuk_content_block_tools/pull/19))

--- a/lib/content_block_tools.rb
+++ b/lib/content_block_tools.rb
@@ -6,6 +6,7 @@ require "uri"
 require "content_block_tools/presenters/base_presenter"
 require "content_block_tools/presenters/email_address_presenter"
 require "content_block_tools/presenters/postal_address_presenter"
+require "content_block_tools/presenters/pension_presenter"
 
 require "content_block_tools/content_block"
 require "content_block_tools/content_block_reference"

--- a/lib/content_block_tools/content_block.rb
+++ b/lib/content_block_tools/content_block.rb
@@ -45,6 +45,7 @@ module ContentBlockTools
     CONTENT_PRESENTERS = {
       "content_block_email_address" => ContentBlockTools::Presenters::EmailAddressPresenter,
       "content_block_postal_address" => ContentBlockTools::Presenters::PostalAddressPresenter,
+      "content_block_pension" => ContentBlockTools::Presenters::PensionPresenter,
     }.freeze
 
     # Calls the appropriate presenter class to return a HTML representation of a content

--- a/lib/content_block_tools/content_block_reference.rb
+++ b/lib/content_block_tools/content_block_reference.rb
@@ -26,7 +26,7 @@ module ContentBlockTools
   #   @return [String]
   class ContentBlockReference < Data
     # An array of the supported document types
-    SUPPORTED_DOCUMENT_TYPES = %w[contact content_block_email_address content_block_postal_address].freeze
+    SUPPORTED_DOCUMENT_TYPES = %w[contact content_block_email_address content_block_postal_address content_block_pension].freeze
     # The regex used to find UUIDs
     UUID_REGEX = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/
     # The regex to find optional field names after the UUID, begins with '/'

--- a/lib/content_block_tools/presenters/pension_presenter.rb
+++ b/lib/content_block_tools/presenters/pension_presenter.rb
@@ -1,0 +1,11 @@
+module ContentBlockTools
+  module Presenters
+    class PensionPresenter < BasePresenter
+    private
+
+      def default_content
+        content_block.title
+      end
+    end
+  end
+end

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "0.4.2"
+  VERSION = "0.4.3"
 end

--- a/spec/content_block_tools/presenters/pension_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/pension_presenter_spec.rb
@@ -1,0 +1,60 @@
+RSpec.describe ContentBlockTools::Presenters::PensionPresenter do
+  let(:content_id) { SecureRandom.uuid }
+  let(:details) do
+    {
+      description: "description of pension",
+    }
+  end
+
+  let(:title) { "Basic state pension" }
+
+  let(:content_block) do
+    ContentBlockTools::ContentBlock.new(
+      document_type: "something",
+      content_id:,
+      title:,
+      details:,
+      embed_code: "{{embed:content_block_pension:#{content_id}}}",
+    )
+  end
+
+  it "should render with the title of the pension" do
+    presenter = described_class.new(content_block)
+    expected_html = <<-HTML
+      <span
+        class="content-embed content-embed__something"
+        data-content-block=""
+        data-document-type="something"
+        data-content-id="#{content_id}"
+        data-embed-code="{{embed:content_block_pension:#{content_id}}}">#{title}</span>
+    HTML
+
+    expect(presenter.render.squish).to eq(expected_html.squish)
+  end
+
+  context "when fields have been defined" do
+    let(:content_block_with_fields) do
+      ContentBlockTools::ContentBlock.new(
+        document_type: "something",
+        content_id:,
+        title: "Pension with fields",
+        details:,
+        embed_code: "{{embed:content_block_pension:#{content_id}/description}}",
+      )
+    end
+
+    it "should render only the value of that field" do
+      presenter = described_class.new(content_block_with_fields)
+      expected_html = <<-HTML
+      <span
+        class="content-embed content-embed__something"
+        data-content-block=""
+        data-document-type="something"
+        data-content-id="#{content_id}"
+        data-embed-code="{{embed:content_block_pension:#{content_id}/description}}">description of pension</span>
+      HTML
+
+      expect(presenter.render.squish).to eq(expected_html.squish)
+    end
+  end
+end


### PR DESCRIPTION

https://trello.com/c/4Nvssgpk/880-enable-embed-codes-for-pension

- **add a basic presenter for pensions**
- **enable pension as supported block type**

This repo is owned by the content modelling team. Please let us know in #govuk-publishing-content-modelling-dev when you raise any PRs.
