### PR TITLE
Add a test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,15 @@ jobs:
           bundler-cache: true
       - run: bundle exec rake
 
+  # Branch protection rules cannot directly depend on status checks from matrix jobs.
+  # So instead we define `test` as a dummy job which only runs after the preceding `test_matrix` checks have passed.
+  # Solution inspired by: https://github.community/t/status-check-for-a-matrix-jobs/127354/3
+  test:
+    needs: test_matrix
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All matrix tests have passed 🚀"
+
   publish:
     needs: test_matrix
     if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
This adds a single dummy test that only runs if the test matrices have all passed. This matches the pattern defined in https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-with-github-actions.html#ci-workflow-for-ruby-gems
