### PR TITLE
symbolise keys in block details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,40 +7,44 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 0.4.4
+
+- symbolize keys in block details blob, in order to find embedded nested fields ([22](https://github.com/alphagov/govuk_content_block_tools/pull/22))
+
 ## 0.4.3
 
-* Add presenter for a pension block ([20](https://github.com/alphagov/govuk_content_block_tools/pull/20))
+- Add presenter for a pension block ([20](https://github.com/alphagov/govuk_content_block_tools/pull/20))
 
 ## 0.4.2
 
-* Pass embed code to HTML span ([19](https://github.com/alphagov/govuk_content_block_tools/pull/19))
+- Pass embed code to HTML span ([19](https://github.com/alphagov/govuk_content_block_tools/pull/19))
 
 ## 0.4.1
 
-* Fix field regular expression ([18](https://github.com/alphagov/govuk_content_block_tools/pull/18))
+- Fix field regular expression ([18](https://github.com/alphagov/govuk_content_block_tools/pull/18))
 
 ## 0.4.0
 
-* BREAKING: allow support for field names in block's embed code. new ContentBlocks now require an embed code argument. (
+- BREAKING: allow support for field names in block's embed code. new ContentBlocks now require an embed code argument. (
   [17]
   (https://github.com/alphagov/govuk_content_block_tools/pull/17))
 
 ## 0.3.1
 
-* Support any Rails version `>= 6` ([#10](https://github.com/alphagov/govuk_content_block_tools/pull/10))
+- Support any Rails version `>= 6` ([#10](https://github.com/alphagov/govuk_content_block_tools/pull/10))
 
 ## 0.3.0
 
-* Symbolise details hash ([#8](https://github.com/alphagov/content_block_tools/pull/8))
+- Symbolise details hash ([#8](https://github.com/alphagov/content_block_tools/pull/8))
 
 ## 0.2.1
 
-* Loosen ActionView dependency ([#7](https://github.com/alphagov/content_block_tools/pull/7))
+- Loosen ActionView dependency ([#7](https://github.com/alphagov/content_block_tools/pull/7))
 
 ## 0.2.0
 
-* Don't `uniq` content references ([#6](https://github.com/alphagov/content_block_tools/pull/6))
+- Don't `uniq` content references ([#6](https://github.com/alphagov/content_block_tools/pull/6))
 
 ## 0.1.0
 
-* Initial release
+- Initial release

--- a/lib/content_block_tools/presenters/base_presenter.rb
+++ b/lib/content_block_tools/presenters/base_presenter.rb
@@ -56,7 +56,7 @@ module ContentBlockTools
       end
 
       def content_for_fields
-        content_block.details.dig(*field_names)
+        content_block.details.deep_symbolize_keys.dig(*field_names)
       end
 
       def field_names

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "0.4.3"
+  VERSION = "0.4.4"
 end

--- a/spec/content_block_tools/presenters/base_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/base_presenter_spec.rb
@@ -80,4 +80,32 @@ RSpec.describe ContentBlockTools::Presenters::BasePresenter do
 
     expect(presenter.render.squish).to eq(expected_html.squish)
   end
+
+  it "should return nested fields if some keys are strings" do
+    content_block_with_nested_fields = ContentBlockTools::ContentBlock.new(
+      document_type: "something",
+      content_id:,
+      title: "My content block",
+      details: {
+        first_field: {
+          second_field: {
+            "third_field" => "hello world",
+          },
+        },
+      },
+      embed_code: "{{embed:content_block_postal_address:#{content_id}/first_field/second_field/third_field}}",
+    )
+
+    presenter = described_class.new(content_block_with_nested_fields)
+    expected_html = <<-HTML
+      <span
+        class="content-embed content-embed__something"
+        data-content-block=""
+        data-document-type="something"
+        data-content-id="#{content_id}"
+        data-embed-code="{{embed:content_block_postal_address:#{content_id}/first_field/second_field/third_field}}">hello world</span>
+    HTML
+
+    expect(presenter.render.squish).to eq(expected_html.squish)
+  end
 end


### PR DESCRIPTION
I noticed when working on nested fields, that for previewing functionalities in Content Block Manager and Whitehall the nested fields weren't working, though they were working in Publishing API when generating the content for the frontend - for some reason on the Whitehall side any nested fields in the `details` are returned with the keys as strings. This prevents that causing a problem hopefully.


---

This repo is owned by the content modelling team. Please let us know in #govuk-publishing-content-modelling-dev when you raise any PRs.
