### PR TITLE
(553) Support content aliases in embed codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 0.5.0
+
+- Support Content ID aliases ([27](https://github.com/alphagov/govuk_content_block_tools/pull/27))
+
 ## 0.4.6
 - Remove noisy log ([25](https://github.com/alphagov/govuk_content_block_tools/pull/25))
 

--- a/lib/content_block_tools/content_block.rb
+++ b/lib/content_block_tools/content_block.rb
@@ -36,10 +36,10 @@ module ContentBlockTools
   #
   # @!attribute [r] embed_code
   #  The embed_code used for a block containing optional field name
-  #   @example
-  #     content_block_reference.embed_code #=> "{{embed:content_block_email_address:2b92cade-549c-4449-9796-e7a3957f3a86}}"
-  #     content_block_reference.embed_code #=> "{{embed:content_block_postal_address:2b92cade-549c-4449-9796-e7a3957f3a86/field_name}}"
-  #   @return [String]
+  #  @example
+  #    content_block_reference.embed_code #=> "{{embed:content_block_email_address:2b92cade-549c-4449-9796-e7a3957f3a86}}"
+  #    content_block_reference.embed_code #=> "{{embed:content_block_postal_address:2b92cade-549c-4449-9796-e7a3957f3a86/field_name}}"
+  #  @return [String]
   class ContentBlock < Data
     # A lookup of presenters for particular content block types
     CONTENT_PRESENTERS = {

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "0.4.6"
+  VERSION = "0.5.0"
 end

--- a/spec/content_block_tools/content_block_reference_spec.rb
+++ b/spec/content_block_tools/content_block_reference_spec.rb
@@ -1,18 +1,40 @@
 RSpec.describe ContentBlockTools::ContentBlockReference do
-  it "initializes correctly" do
-    content_id = SecureRandom.uuid
-    document_type = "content_block_email_address"
-    embed_code = "{{embed:content_block_email_address:#{SecureRandom.uuid}}}"
+  let(:content_id) { SecureRandom.uuid }
+  let(:document_type) { "content_block_email_address" }
+  let(:embed_code) { "{{embed:content_block_email_address:#{SecureRandom.uuid}}}" }
 
+  it "initializes correctly" do
     content_block = described_class.new(
       document_type:,
-      content_id:,
+      identifier: content_id,
       embed_code:,
     )
 
     expect(content_block.document_type).to eq(document_type)
-    expect(content_block.content_id).to eq(content_id)
+    expect(content_block.identifier).to eq(content_id)
     expect(content_block.embed_code).to eq(embed_code)
+  end
+
+  describe "#identifier_is_alias?" do
+    it "returns true when the identifier is an alias" do
+      content_block = described_class.new(
+        document_type:,
+        identifier: "some-alias",
+        embed_code:,
+      )
+
+      expect(content_block.identifier_is_alias?).to be true
+    end
+
+    it "returns false when the identifier is a UUID" do
+      content_block = described_class.new(
+        document_type:,
+        identifier: content_id,
+        embed_code:,
+      )
+
+      expect(content_block.identifier_is_alias?).to be false
+    end
   end
 
   describe ".find_all_in_document" do
@@ -26,7 +48,7 @@ RSpec.describe ContentBlockTools::ContentBlockReference do
       end
     end
 
-    describe "when there is embedded content" do
+    describe "when there is embedded content with a UUID" do
       let(:contact_uuid) { SecureRandom.uuid }
       let(:content_block_email_address_uuid) { SecureRandom.uuid }
 
@@ -45,11 +67,11 @@ RSpec.describe ContentBlockTools::ContentBlockReference do
           expect(result.count).to eq(2)
 
           expect(result[0].document_type).to eq("contact")
-          expect(result[0].content_id).to eq(contact_uuid)
+          expect(result[0].identifier).to eq(contact_uuid)
           expect(result[0].embed_code).to eq("{{embed:contact:#{contact_uuid}}}")
 
           expect(result[1].document_type).to eq("content_block_email_address")
-          expect(result[1].content_id).to eq(content_block_email_address_uuid)
+          expect(result[1].identifier).to eq(content_block_email_address_uuid)
           expect(result[1].embed_code).to eq("{{embed:content_block_email_address:#{content_block_email_address_uuid}}}")
         end
 
@@ -65,9 +87,9 @@ RSpec.describe ContentBlockTools::ContentBlockReference do
           it "retains the duplicates" do
             expect(result.count).to eq(3)
 
-            expect(result[0].content_id).to eq(contact_uuid)
-            expect(result[1].content_id).to eq(contact_uuid)
-            expect(result[2].content_id).to eq(content_block_email_address_uuid)
+            expect(result[0].identifier).to eq(contact_uuid)
+            expect(result[1].identifier).to eq(contact_uuid)
+            expect(result[2].identifier).to eq(content_block_email_address_uuid)
           end
         end
 
@@ -87,16 +109,74 @@ RSpec.describe ContentBlockTools::ContentBlockReference do
             expect(result.count).to eq(3)
 
             expect(result[0].document_type).to eq("contact")
-            expect(result[0].content_id).to eq(contact_uuid)
+            expect(result[0].identifier).to eq(contact_uuid)
             expect(result[0].embed_code).to eq("{{embed:contact:#{contact_uuid}/example_field_1}}")
 
             expect(result[1].document_type).to eq("contact")
-            expect(result[1].content_id).to eq(contact_uuid)
+            expect(result[1].identifier).to eq(contact_uuid)
             expect(result[1].embed_code).to eq("{{embed:contact:#{contact_uuid}/example_field_2}}")
 
             expect(result[2].document_type).to eq("content_block_email_address")
-            expect(result[2].content_id).to eq(content_block_email_address_uuid)
+            expect(result[2].identifier).to eq(content_block_email_address_uuid)
             expect(result[2].embed_code).to eq("{{embed:content_block_email_address:#{content_block_email_address_uuid}/another_field}}")
+          end
+        end
+      end
+    end
+
+    describe "when there is embedded content with an alias" do
+      let(:contact_alias) { "contact-alias" }
+      let(:content_block_email_address_alias) { "email-address-alias" }
+
+      let(:document) do
+        "
+        {{embed:contact:#{contact_alias}}}
+        {{embed:content_block_email_address:#{content_block_email_address_alias}}}
+      "
+      end
+
+      describe "#content_references" do
+        it "returns all references" do
+          expect(ContentBlockTools.logger).to receive(:info).with("Found Content Block Reference: [\"{{embed:contact:#{contact_alias}}}\", \"contact\", \"#{contact_alias}\", nil]")
+          expect(ContentBlockTools.logger).to receive(:info).with("Found Content Block Reference: [\"{{embed:content_block_email_address:#{content_block_email_address_alias}}}\", \"content_block_email_address\", \"#{content_block_email_address_alias}\", nil]")
+
+          expect(result.count).to eq(2)
+
+          expect(result[0].document_type).to eq("contact")
+          expect(result[0].identifier).to eq(contact_alias)
+          expect(result[0].embed_code).to eq("{{embed:contact:#{contact_alias}}}")
+
+          expect(result[1].document_type).to eq("content_block_email_address")
+          expect(result[1].identifier).to eq(content_block_email_address_alias)
+          expect(result[1].embed_code).to eq("{{embed:content_block_email_address:#{content_block_email_address_alias}}}")
+        end
+
+        context "when there are fields in the embed code" do
+          let(:contact_alias) { "contact-alias" }
+          let(:content_block_email_address_alias) { "email-address-alias" }
+
+          let(:document) do
+            "
+              {{embed:contact:#{contact_alias}/example_field_1}}
+              {{embed:contact:#{contact_alias}/example_field_2}}
+              {{embed:content_block_email_address:#{content_block_email_address_alias}/another_field}}
+            ".squish
+          end
+
+          it "finds all the references" do
+            expect(result.count).to eq(3)
+
+            expect(result[0].document_type).to eq("contact")
+            expect(result[0].identifier).to eq(contact_alias)
+            expect(result[0].embed_code).to eq("{{embed:contact:#{contact_alias}/example_field_1}}")
+
+            expect(result[1].document_type).to eq("contact")
+            expect(result[1].identifier).to eq(contact_alias)
+            expect(result[1].embed_code).to eq("{{embed:contact:#{contact_alias}/example_field_2}}")
+
+            expect(result[2].document_type).to eq("content_block_email_address")
+            expect(result[2].identifier).to eq(content_block_email_address_alias)
+            expect(result[2].embed_code).to eq("{{embed:content_block_email_address:#{content_block_email_address_alias}/another_field}}")
           end
         end
       end

--- a/spec/content_block_tools/content_block_reference_spec.rb
+++ b/spec/content_block_tools/content_block_reference_spec.rb
@@ -99,9 +99,9 @@ RSpec.describe ContentBlockTools::ContentBlockReference do
 
           let(:document) do
             "
-              {{embed:contact:#{contact_uuid}/example_field_1}}
-              {{embed:contact:#{contact_uuid}/example_field_2}}
-              {{embed:content_block_email_address:#{content_block_email_address_uuid}/another_field}}
+              {{embed:contact:#{contact_uuid}/example-field-1}}
+              {{embed:contact:#{contact_uuid}/example-field-2}}
+              {{embed:content_block_email_address:#{content_block_email_address_uuid}/another-field}}
             ".squish
           end
 
@@ -110,15 +110,15 @@ RSpec.describe ContentBlockTools::ContentBlockReference do
 
             expect(result[0].document_type).to eq("contact")
             expect(result[0].identifier).to eq(contact_uuid)
-            expect(result[0].embed_code).to eq("{{embed:contact:#{contact_uuid}/example_field_1}}")
+            expect(result[0].embed_code).to eq("{{embed:contact:#{contact_uuid}/example-field-1}}")
 
             expect(result[1].document_type).to eq("contact")
             expect(result[1].identifier).to eq(contact_uuid)
-            expect(result[1].embed_code).to eq("{{embed:contact:#{contact_uuid}/example_field_2}}")
+            expect(result[1].embed_code).to eq("{{embed:contact:#{contact_uuid}/example-field-2}}")
 
             expect(result[2].document_type).to eq("content_block_email_address")
             expect(result[2].identifier).to eq(content_block_email_address_uuid)
-            expect(result[2].embed_code).to eq("{{embed:content_block_email_address:#{content_block_email_address_uuid}/another_field}}")
+            expect(result[2].embed_code).to eq("{{embed:content_block_email_address:#{content_block_email_address_uuid}/another-field}}")
           end
         end
       end
@@ -157,9 +157,9 @@ RSpec.describe ContentBlockTools::ContentBlockReference do
 
           let(:document) do
             "
-              {{embed:contact:#{contact_alias}/example_field_1}}
-              {{embed:contact:#{contact_alias}/example_field_2}}
-              {{embed:content_block_email_address:#{content_block_email_address_alias}/another_field}}
+              {{embed:contact:#{contact_alias}/example-field-1}}
+              {{embed:contact:#{contact_alias}/example-field-2}}
+              {{embed:content_block_email_address:#{content_block_email_address_alias}/another-field}}
             ".squish
           end
 
@@ -168,15 +168,15 @@ RSpec.describe ContentBlockTools::ContentBlockReference do
 
             expect(result[0].document_type).to eq("contact")
             expect(result[0].identifier).to eq(contact_alias)
-            expect(result[0].embed_code).to eq("{{embed:contact:#{contact_alias}/example_field_1}}")
+            expect(result[0].embed_code).to eq("{{embed:contact:#{contact_alias}/example-field-1}}")
 
             expect(result[1].document_type).to eq("contact")
             expect(result[1].identifier).to eq(contact_alias)
-            expect(result[1].embed_code).to eq("{{embed:contact:#{contact_alias}/example_field_2}}")
+            expect(result[1].embed_code).to eq("{{embed:contact:#{contact_alias}/example-field-2}}")
 
             expect(result[2].document_type).to eq("content_block_email_address")
             expect(result[2].identifier).to eq(content_block_email_address_alias)
-            expect(result[2].embed_code).to eq("{{embed:content_block_email_address:#{content_block_email_address_alias}/another_field}}")
+            expect(result[2].embed_code).to eq("{{embed:content_block_email_address:#{content_block_email_address_alias}/another-field}}")
           end
         end
       end


### PR DESCRIPTION
Trello card: https://trello.com/c/fdJtXlmL/553-tech-spike-investigate-friendly-names-for-content-blocks-embed-codes

This adds support for Content ID aliases as well as UUIDs in embed codes, as well as adding a helper to define what type of content id was provided.