### PR TITLE
(CM-51) Create a presenter for contact blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+- Update dependencies
+- Create a presenter for Contact Blocks ([30](https://github.com/alphagov/govuk_content_block_tools/pull/30))
+
 ## 0.5.0
 
 - Support Content ID aliases ([27](https://github.com/alphagov/govuk_content_block_tools/pull/27))

--- a/content_block_tools.gemspec
+++ b/content_block_tools.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake", "13.2.1"
   spec.add_development_dependency "rspec", "3.13.0"
+  spec.add_development_dependency "rspec-html-matchers", "0.10.0"
   spec.add_development_dependency "rubocop-govuk", "5.1.6"
 
   spec.add_dependency "actionview", ">= 6"

--- a/lib/content_block_tools.rb
+++ b/lib/content_block_tools.rb
@@ -9,6 +9,8 @@ require "content_block_tools/presenters/email_address_presenter"
 require "content_block_tools/presenters/postal_address_presenter"
 require "content_block_tools/presenters/pension_presenter"
 
+require "content_block_tools/presenters/field_presenters/base_presenter"
+
 require "content_block_tools/content_block"
 require "content_block_tools/content_block_reference"
 

--- a/lib/content_block_tools.rb
+++ b/lib/content_block_tools.rb
@@ -10,6 +10,7 @@ require "content_block_tools/presenters/postal_address_presenter"
 require "content_block_tools/presenters/pension_presenter"
 
 require "content_block_tools/presenters/field_presenters/base_presenter"
+require "content_block_tools/presenters/field_presenters/contact/email_address_presenter"
 
 require "content_block_tools/content_block"
 require "content_block_tools/content_block_reference"

--- a/lib/content_block_tools.rb
+++ b/lib/content_block_tools.rb
@@ -3,14 +3,14 @@
 require "action_view"
 require "uri"
 
+require "content_block_tools/presenters/field_presenters/base_presenter"
+require "content_block_tools/presenters/field_presenters/contact/email_address_presenter"
+
 require "content_block_tools/presenters/base_presenter"
 require "content_block_tools/presenters/contact_presenter"
 require "content_block_tools/presenters/email_address_presenter"
 require "content_block_tools/presenters/postal_address_presenter"
 require "content_block_tools/presenters/pension_presenter"
-
-require "content_block_tools/presenters/field_presenters/base_presenter"
-require "content_block_tools/presenters/field_presenters/contact/email_address_presenter"
 
 require "content_block_tools/content_block"
 require "content_block_tools/content_block_reference"

--- a/lib/content_block_tools.rb
+++ b/lib/content_block_tools.rb
@@ -4,6 +4,7 @@ require "action_view"
 require "uri"
 
 require "content_block_tools/presenters/base_presenter"
+require "content_block_tools/presenters/contact_presenter"
 require "content_block_tools/presenters/email_address_presenter"
 require "content_block_tools/presenters/postal_address_presenter"
 require "content_block_tools/presenters/pension_presenter"

--- a/lib/content_block_tools/content_block.rb
+++ b/lib/content_block_tools/content_block.rb
@@ -43,6 +43,7 @@ module ContentBlockTools
   class ContentBlock < Data
     # A lookup of presenters for particular content block types
     CONTENT_PRESENTERS = {
+      "content_block_contact" => ContentBlockTools::Presenters::ContactPresenter,
       "content_block_email_address" => ContentBlockTools::Presenters::EmailAddressPresenter,
       "content_block_postal_address" => ContentBlockTools::Presenters::PostalAddressPresenter,
       "content_block_pension" => ContentBlockTools::Presenters::PensionPresenter,

--- a/lib/content_block_tools/content_block_reference.rb
+++ b/lib/content_block_tools/content_block_reference.rb
@@ -28,7 +28,7 @@ module ContentBlockTools
   #   @return [String]
   class ContentBlockReference < Data
     # An array of the supported document types
-    SUPPORTED_DOCUMENT_TYPES = %w[contact content_block_email_address content_block_postal_address content_block_pension].freeze
+    SUPPORTED_DOCUMENT_TYPES = %w[contact content_block_email_address content_block_postal_address content_block_pension content_block_contact].freeze
     # The regex used to find UUIDs
     UUID_REGEX = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
     # The regex used to find content ID aliases

--- a/lib/content_block_tools/presenters/base_presenter.rb
+++ b/lib/content_block_tools/presenters/base_presenter.rb
@@ -1,6 +1,7 @@
 module ContentBlockTools
   module Presenters
     class BasePresenter
+      include ActionView::Context
       include ActionView::Helpers::TagHelper
 
       # The default HTML tag to wrap the presented response in - can be overridden in a subclass
@@ -22,7 +23,7 @@ module ContentBlockTools
       # @return [string] A HTML representation of the content block
       def render
         content_tag(
-          BASE_TAG_TYPE,
+          self.class::BASE_TAG_TYPE,
           content,
           class: %W[content-embed content-embed__#{content_block.document_type}],
           data: {

--- a/lib/content_block_tools/presenters/base_presenter.rb
+++ b/lib/content_block_tools/presenters/base_presenter.rb
@@ -7,6 +7,9 @@ module ContentBlockTools
       # The default HTML tag to wrap the presented response in - can be overridden in a subclass
       BASE_TAG_TYPE = :span
 
+      # A lookup of presenters for particular fields - can be overridden in a subclass
+      FIELD_PRESENTERS = {}.freeze
+
       # Returns a new presenter object
       #
       # @param [{ContentBlockTools::ContentBlock}] content_block  A content block object
@@ -63,7 +66,8 @@ module ContentBlockTools
           ContentBlockTools.logger.warn("Content not found for content block #{content_block.content_id} and fields #{field_names}")
           content_block.embed_code
         else
-          content
+          presenter = self.class::FIELD_PRESENTERS[field_names.last] || ContentBlockTools::Presenters::FieldPresenters::BasePresenter
+          presenter.new(content).render
         end
       end
 

--- a/lib/content_block_tools/presenters/contact_presenter.rb
+++ b/lib/content_block_tools/presenters/contact_presenter.rb
@@ -5,6 +5,10 @@ module ContentBlockTools
 
       BASE_TAG_TYPE = :div
 
+      FIELD_PRESENTERS = {
+        email_address: ContentBlockTools::Presenters::FieldPresenters::Contact::EmailAddressPresenter,
+      }.freeze
+
     private
 
       def default_content

--- a/lib/content_block_tools/presenters/contact_presenter.rb
+++ b/lib/content_block_tools/presenters/contact_presenter.rb
@@ -1,0 +1,47 @@
+module ContentBlockTools
+  module Presenters
+    class ContactPresenter < BasePresenter
+      include ActionView::Helpers::TextHelper
+
+      BASE_TAG_TYPE = :div
+
+    private
+
+      def default_content
+        content_tag(:div, class: "contact") do
+          concat content_tag(:p, content_block.title, class: "govuk-body")
+          concat(email_addresses.map { |email_address| email_address_content(email_address) }.join.html_safe) if email_addresses.any?
+          concat(phone_numbers.map { |phone_number| phone_number_content(phone_number) }.join.html_safe) if phone_numbers.any?
+        end
+      end
+
+      def email_address_content(email_address)
+        content_tag(:p, class: "govuk-body govuk-!-margin-bottom-4") do
+          concat content_tag(:span, email_address[:title])
+          concat content_tag(:a,
+                             email_address[:email_address],
+                             class: "govuk-link",
+                             href: "mailto:#{email_address[:email_address]}")
+        end
+      end
+
+      def phone_number_content(phone_number)
+        content_tag(:p, class: "govuk-body govuk-!-margin-bottom-4") do
+          concat content_tag(:span, phone_number[:title])
+          concat content_tag(:a,
+                             phone_number[:telephone],
+                             class: "govuk-link",
+                             href: "tel:#{CGI.escape phone_number[:telephone]}")
+        end
+      end
+
+      def email_addresses
+        content_block.details[:email_addresses]&.values
+      end
+
+      def phone_numbers
+        content_block.details[:telephones]&.values
+      end
+    end
+  end
+end

--- a/lib/content_block_tools/presenters/email_address_presenter.rb
+++ b/lib/content_block_tools/presenters/email_address_presenter.rb
@@ -4,7 +4,10 @@ module ContentBlockTools
     private
 
       def content
-        content_block.details[:email_address]
+        content_tag(:a,
+                    content_block.details[:email_address],
+                    class: "govuk-link",
+                    href: "mailto:#{content_block.details[:email_address]}")
       end
     end
   end

--- a/lib/content_block_tools/presenters/field_presenters/base_presenter.rb
+++ b/lib/content_block_tools/presenters/field_presenters/base_presenter.rb
@@ -2,6 +2,9 @@ module ContentBlockTools
   module Presenters
     module FieldPresenters
       class BasePresenter
+        include ActionView::Context
+        include ActionView::Helpers::TagHelper
+
         attr_reader :field
 
         def initialize(field)

--- a/lib/content_block_tools/presenters/field_presenters/base_presenter.rb
+++ b/lib/content_block_tools/presenters/field_presenters/base_presenter.rb
@@ -1,0 +1,17 @@
+module ContentBlockTools
+  module Presenters
+    module FieldPresenters
+      class BasePresenter
+        attr_reader :field
+
+        def initialize(field)
+          @field = field
+        end
+
+        def render
+          field
+        end
+      end
+    end
+  end
+end

--- a/lib/content_block_tools/presenters/field_presenters/contact/email_address_presenter.rb
+++ b/lib/content_block_tools/presenters/field_presenters/contact/email_address_presenter.rb
@@ -1,0 +1,13 @@
+module ContentBlockTools
+  module Presenters
+    module FieldPresenters
+      module Contact
+        class EmailAddressPresenter < BasePresenter
+          def render
+            content_tag(:a, field, class: "govuk-link", href: "mailto:#{field}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/content_block_tools/content_block_spec.rb
+++ b/spec/content_block_tools/content_block_spec.rb
@@ -50,6 +50,16 @@ RSpec.describe ContentBlockTools::ContentBlock do
       end
     end
 
+    context "when a contact" do
+      let(:document_type) { "content_block_contact" }
+      let(:presenter_class) { ContentBlockTools::Presenters::ContactPresenter }
+
+      it "calls the contact presenter" do
+        expect(content_block.render).to eq(render_response)
+        expect(presenter_double).to have_received(:render)
+      end
+    end
+
     context "when presenter can't be found" do
       let(:document_type) { "contact" }
       let(:presenter_class) { ContentBlockTools::Presenters::BasePresenter }

--- a/spec/content_block_tools/presenters/base_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/base_presenter_spec.rb
@@ -111,4 +111,33 @@ RSpec.describe ContentBlockTools::Presenters::BasePresenter do
       ),
     )
   end
+
+  it "should render fields with the base presenter" do
+    presenter_class = ContentBlockTools::Presenters::FieldPresenters::BasePresenter
+
+    render_response = "STUB_RESPONSE"
+    presenter_double = double(presenter_class, render: render_response)
+
+    content_block_with_nested_fields = ContentBlockTools::ContentBlock.new(
+      document_type: "something",
+      content_id:,
+      title: "My content block",
+      details: {
+        first_field: {
+          second_field: {
+            third_field: "hello world",
+          },
+        },
+      },
+      embed_code: "{{embed:content_block_postal_address:#{content_id}/first_field/second_field/third_field}}",
+    )
+
+    expect(presenter_class).to receive(:new).with("hello world") {
+      presenter_double
+    }
+
+    described_class.new(content_block_with_nested_fields).render
+
+    expect(presenter_double).to have_received(:render)
+  end
 end

--- a/spec/content_block_tools/presenters/base_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/base_presenter_spec.rb
@@ -11,20 +11,22 @@ RSpec.describe ContentBlockTools::Presenters::BasePresenter do
     )
   end
 
+  let(:expected_wrapper_attributes) do
+    {
+      class: "content-embed content-embed__something",
+      "data-content-block" => "",
+      "data-document-type" => "something",
+      "data-content-id" => content_id,
+      "data-embed-code" => "something",
+    }
+  end
+
   it "should render with the title" do
     presenter = described_class.new(content_block)
-    expected_html = <<-HTML
-      <span
-        class="content-embed content-embed__something"
-        data-content-block=""
-        data-document-type="something"
-        data-content-id="#{content_id}"
-        data-embed-code="something">My content block</span>
-    HTML
 
     expect(ContentBlockTools.logger).to receive(:info).with("Getting content for content block #{content_id}")
 
-    expect(presenter.render.squish).to eq(expected_html.squish)
+    expect(presenter.render).to have_tag("span", text: "My content block", with: expected_wrapper_attributes)
   end
 
   it "should render nested fields" do
@@ -43,16 +45,14 @@ RSpec.describe ContentBlockTools::Presenters::BasePresenter do
     )
 
     presenter = described_class.new(content_block_with_nested_fields)
-    expected_html = <<-HTML
-      <span
-        class="content-embed content-embed__something"
-        data-content-block=""
-        data-document-type="something"
-        data-content-id="#{content_id}"
-        data-embed-code="{{embed:content_block_postal_address:#{content_id}/first_field/second_field/third_field}}">hello world</span>
-    HTML
 
-    expect(presenter.render.squish).to eq(expected_html.squish)
+    expect(presenter.render).to have_tag(
+      "span",
+      text: "hello world",
+      with: expected_wrapper_attributes.merge(
+        "data-embed-code" => "{{embed:content_block_postal_address:#{content_id}/first_field/second_field/third_field}}",
+      ),
+    )
   end
 
   it "should return the embed code if a given field does not exist" do
@@ -71,18 +71,18 @@ RSpec.describe ContentBlockTools::Presenters::BasePresenter do
     )
 
     presenter = described_class.new(content_block_with_nested_fields)
-    expected_html = <<-HTML
-      <span
-        class="content-embed content-embed__something"
-        data-content-block=""
-        data-document-type="something"
-        data-content-id="#{content_id}"
-        data-embed-code="{{embed:content_block_postal_address:#{content_id}/first_field/second_field/fake_field}}">{{embed:content_block_postal_address:#{content_id}/first_field/second_field/fake_field}}</span>
-    HTML
 
     expect(ContentBlockTools.logger).to receive(:warn).with("Content not found for content block #{content_id} and fields [:first_field, :second_field, :fake_field]")
 
-    expect(presenter.render.squish).to eq(expected_html.squish)
+    embed_code = "{{embed:content_block_postal_address:#{content_id}/first_field/second_field/fake_field}}"
+
+    expect(presenter.render).to have_tag(
+      "span",
+      text: embed_code,
+      with: expected_wrapper_attributes.merge(
+        "data-embed-code" => embed_code,
+      ),
+    )
   end
 
   it "should return nested fields if some keys are strings" do
@@ -101,15 +101,14 @@ RSpec.describe ContentBlockTools::Presenters::BasePresenter do
     )
 
     presenter = described_class.new(content_block_with_nested_fields)
-    expected_html = <<-HTML
-      <span
-        class="content-embed content-embed__something"
-        data-content-block=""
-        data-document-type="something"
-        data-content-id="#{content_id}"
-        data-embed-code="{{embed:content_block_postal_address:#{content_id}/first_field/second_field/third_field}}">hello world</span>
-    HTML
+    embed_code = "{{embed:content_block_postal_address:#{content_id}/first_field/second_field/third_field}}"
 
-    expect(presenter.render.squish).to eq(expected_html.squish)
+    expect(presenter.render).to have_tag(
+      "span",
+      text: "hello world",
+      with: expected_wrapper_attributes.merge(
+        "data-embed-code" => embed_code,
+      ),
+    )
   end
 end

--- a/spec/content_block_tools/presenters/contact_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/contact_presenter_spec.rb
@@ -60,17 +60,19 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
     end
 
     it "should render an email address when embed code is provided" do
+      embed_code = "{{embed:content_block_contact:#{content_id}/email_addresses/foo/email_address}}"
+
       content_block = ContentBlockTools::ContentBlock.new(
         document_type: "contact",
         content_id:,
         title: "My Contact",
         details: { email_addresses: email_addresses, telephones: telephones },
-        embed_code: "{{embed:content_block:#{content_id}/email_addresses/foo/email_address}}",
+        embed_code:,
       )
 
       presenter = described_class.new(content_block)
 
-      expect(presenter.render).to have_tag("div", with: expected_wrapper_attributes.merge({ "data-embed-code" => "{{embed:content_block:#{content_id}/email_addresses/foo/email_address}}" })) do
+      expect(presenter.render).to have_tag("span", with: expected_wrapper_attributes.merge({ "data-embed-code" => embed_code })) do
         with_tag(
           :a,
           text: "foo@example.com",

--- a/spec/content_block_tools/presenters/contact_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/contact_presenter_spec.rb
@@ -1,0 +1,87 @@
+RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
+  let(:content_id) { SecureRandom.uuid }
+  let(:email_addresses) { {} }
+  let(:telephones) { {} }
+
+  let(:content_block) do
+    ContentBlockTools::ContentBlock.new(
+      document_type: "contact",
+      content_id:,
+      title: "My Contact",
+      details: { email_addresses: email_addresses, telephones: telephones },
+      embed_code: "something",
+    )
+  end
+
+  let(:expected_wrapper_attributes) do
+    {
+      class: "content-embed content-embed__contact",
+      "data-content-block" => "",
+      "data-document-type" => "contact",
+      "data-content-id" => content_id,
+      "data-embed-code" => "something",
+    }
+  end
+
+  describe "when no content items are present" do
+    it "should render successfully" do
+      presenter = described_class.new(content_block)
+
+      expect(presenter.render).to have_tag("div", with: expected_wrapper_attributes) do
+        with_tag("div", with: { class: "contact" }) do
+          with_tag("p", text: "My Contact", with: { class: "govuk-body" })
+        end
+      end
+    end
+  end
+
+  describe "when email addresses are present" do
+    let(:email_addresses) do
+      {
+        "foo": {
+          "title": "Some email address",
+          "email_address": "foo@example.com",
+        },
+      }
+    end
+
+    it "should render successfully" do
+      presenter = described_class.new(content_block)
+
+      expect(presenter.render).to have_tag("div", with: expected_wrapper_attributes) do
+        with_tag("div", with: { class: "contact" }) do
+          with_tag("p", text: "My Contact", with: { class: "govuk-body" })
+          with_tag("p", with: { class: "govuk-body" }) do
+            with_tag("span", text: "Some email address")
+            with_tag("a", text: "foo@example.com", with: { href: "mailto:foo@example.com", class: "govuk-link" })
+          end
+        end
+      end
+    end
+  end
+
+  describe "when phone numbers are present" do
+    let(:telephones) do
+      {
+        "foo": {
+          "title": "Some phone number",
+          "telephone": "0891 50 50 50",
+        },
+      }
+    end
+
+    it "should render successfully" do
+      presenter = described_class.new(content_block)
+
+      expect(presenter.render).to have_tag("div", with: expected_wrapper_attributes) do
+        with_tag("div", with: { class: "contact" }) do
+          with_tag("p", text: "My Contact", with: { class: "govuk-body" })
+          with_tag("p", with: { class: "govuk-body" }) do
+            with_tag("span", text: "Some phone number")
+            with_tag("a", text: "0891 50 50 50", with: { href: "tel:0891+50+50+50", class: "govuk-link" })
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/content_block_tools/presenters/contact_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/contact_presenter_spec.rb
@@ -58,6 +58,26 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
         end
       end
     end
+
+    it "should render an email address when embed code is provided" do
+      content_block = ContentBlockTools::ContentBlock.new(
+        document_type: "contact",
+        content_id:,
+        title: "My Contact",
+        details: { email_addresses: email_addresses, telephones: telephones },
+        embed_code: "{{embed:content_block:#{content_id}/email_addresses/foo/email_address}}",
+      )
+
+      presenter = described_class.new(content_block)
+
+      expect(presenter.render).to have_tag("div", with: expected_wrapper_attributes.merge({ "data-embed-code" => "{{embed:content_block:#{content_id}/email_addresses/foo/email_address}}" })) do
+        with_tag(
+          :a,
+          text: "foo@example.com",
+          with: { href: "mailto:foo@example.com", class: "govuk-link" },
+        )
+      end
+    end
   end
 
   describe "when phone numbers are present" do

--- a/spec/content_block_tools/presenters/email_address_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/email_address_presenter_spec.rb
@@ -15,12 +15,18 @@ RSpec.describe ContentBlockTools::Presenters::EmailAddressPresenter do
   it "should render with the email address" do
     presenter = described_class.new(content_block)
 
-    expect(presenter.render).to have_tag("span", text: email_address, with: {
+    expect(presenter.render).to have_tag("span", with: {
       class: "content-embed content-embed__something",
       "data-content-block" => "",
       "data-document-type" => "something",
       "data-content-id" => content_id,
       "data-embed-code" => "something",
-    })
+    }) do
+      with_tag(
+        :a,
+        text: email_address,
+        with: { href: "mailto:#{email_address}", class: "govuk-link" },
+      )
+    end
   end
 end

--- a/spec/content_block_tools/presenters/email_address_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/email_address_presenter_spec.rb
@@ -14,15 +14,13 @@ RSpec.describe ContentBlockTools::Presenters::EmailAddressPresenter do
 
   it "should render with the email address" do
     presenter = described_class.new(content_block)
-    expected_html = <<-HTML
-      <span
-        class="content-embed content-embed__something"
-        data-content-block=""
-        data-document-type="something"
-        data-content-id="#{content_id}"
-        data-embed-code="something">#{email_address}</span>
-    HTML
 
-    expect(presenter.render.squish).to eq(expected_html.squish)
+    expect(presenter.render).to have_tag("span", text: email_address, with: {
+      class: "content-embed content-embed__something",
+      "data-content-block" => "",
+      "data-document-type" => "something",
+      "data-content-id" => content_id,
+      "data-embed-code" => "something",
+    })
   end
 end

--- a/spec/content_block_tools/presenters/field_presenters/contact/email_address_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/field_presenters/contact/email_address_presenter_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe ContentBlockTools::Presenters::FieldPresenters::Contact::EmailAddressPresenter do
+  it "presents an email address" do
+    email_address = "foo@example.com"
+
+    presenter = described_class.new(email_address)
+
+    expect(presenter.render).to have_tag(
+      :a,
+      text: email_address,
+      with: { href: "mailto:#{email_address}", class: "govuk-link" },
+    )
+  end
+end

--- a/spec/content_block_tools/presenters/pension_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/pension_presenter_spec.rb
@@ -20,16 +20,14 @@ RSpec.describe ContentBlockTools::Presenters::PensionPresenter do
 
   it "should render with the title of the pension" do
     presenter = described_class.new(content_block)
-    expected_html = <<-HTML
-      <span
-        class="content-embed content-embed__something"
-        data-content-block=""
-        data-document-type="something"
-        data-content-id="#{content_id}"
-        data-embed-code="{{embed:content_block_pension:#{content_id}}}">#{title}</span>
-    HTML
 
-    expect(presenter.render.squish).to eq(expected_html.squish)
+    expect(presenter.render).to have_tag("span", text: title, with: {
+      class: "content-embed content-embed__something",
+      "data-content-block" => "",
+      "data-document-type" => "something",
+      "data-content-id" => content_id,
+      "data-embed-code" => "{{embed:content_block_pension:#{content_id}}}",
+    })
   end
 
   context "when fields have been defined" do
@@ -45,16 +43,14 @@ RSpec.describe ContentBlockTools::Presenters::PensionPresenter do
 
     it "should render only the value of that field" do
       presenter = described_class.new(content_block_with_fields)
-      expected_html = <<-HTML
-      <span
-        class="content-embed content-embed__something"
-        data-content-block=""
-        data-document-type="something"
-        data-content-id="#{content_id}"
-        data-embed-code="{{embed:content_block_pension:#{content_id}/description}}">description of pension</span>
-      HTML
 
-      expect(presenter.render.squish).to eq(expected_html.squish)
+      expect(presenter.render).to have_tag("span", text: "description of pension", with: {
+        class: "content-embed content-embed__something",
+        "data-content-block" => "",
+        "data-document-type" => "something",
+        "data-content-id" => content_id,
+        "data-embed-code" => "{{embed:content_block_pension:#{content_id}/description}}",
+      })
     end
   end
 end

--- a/spec/content_block_tools/presenters/postal_address_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/postal_address_presenter_spec.rb
@@ -24,16 +24,14 @@ RSpec.describe ContentBlockTools::Presenters::PostalAddressPresenter do
 
   it "should render with the postal address" do
     presenter = described_class.new(content_block)
-    expected_html = <<-HTML
-      <span
-        class="content-embed content-embed__something"
-        data-content-block=""
-        data-document-type="something"
-        data-content-id="#{content_id}"
-        data-embed-code="{{embed:content_block_postal_address:#{content_id}}}">#{postal_html_string}</span>
-    HTML
 
-    expect(presenter.render.squish).to eq(expected_html.squish)
+    expect(presenter.render).to have_tag("span", text: postal_html_string, with: {
+      class: "content-embed content-embed__something",
+      "data-content-block" => "",
+      "data-document-type" => "something",
+      "data-content-id" => content_id,
+      "data-embed-code" => "{{embed:content_block_postal_address:#{content_id}}}",
+    })
   end
 
   context "when fields have been defined" do
@@ -59,30 +57,28 @@ RSpec.describe ContentBlockTools::Presenters::PostalAddressPresenter do
 
     it "should render only the value of that field" do
       presenter = described_class.new(content_block_with_fields)
-      expected_html = <<-HTML
-      <span
-        class="content-embed content-embed__something"
-        data-content-block=""
-        data-document-type="something"
-        data-content-id="#{content_id}"
-        data-embed-code="{{embed:content_block_postal_address:#{content_id}/town_or_city}}">Somewhereville</span>
-      HTML
 
-      expect(presenter.render.squish).to eq(expected_html.squish)
+      expect(presenter.render).to have_tag("span", text: "Somewhereville", with: {
+        class: "content-embed content-embed__something",
+        "data-content-block" => "",
+        "data-document-type" => "something",
+        "data-content-id" => content_id,
+        "data-embed-code" => "{{embed:content_block_postal_address:#{content_id}/town_or_city}}",
+      })
     end
 
     it "should return the embed code if given a fake field" do
       presenter = described_class.new(content_block_with_fake_fields)
-      expected_html = <<-HTML
-      <span
-        class="content-embed content-embed__something"
-        data-content-block=""
-        data-document-type="something"
-        data-content-id="#{content_id}"
-        data-embed-code="{{embed:content_block_postal_address:#{content_id}/nothing}}">{{embed:content_block_postal_address:#{content_id}/nothing}}</span>
-      HTML
 
-      expect(presenter.render.squish).to eq(expected_html.squish)
+      embed_code = "{{embed:content_block_postal_address:#{content_id}/nothing}}"
+
+      expect(presenter.render).to have_tag("span", text: embed_code, with: {
+        class: "content-embed content-embed__something",
+        "data-content-block" => "",
+        "data-document-type" => "something",
+        "data-content-id" => content_id,
+        "data-embed-code" => embed_code,
+      })
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,10 +2,13 @@
 
 require "bundler/setup"
 require "securerandom"
+require "rspec-html-matchers"
 
 require "content_block_tools"
 
 RSpec.configure do |config|
+  config.include RSpecHtmlMatchers
+
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
 


### PR DESCRIPTION
This creates a presenter for contact blocks - if no field is provided, we show all the values (in a similar way to how Whitehall present contacts), otherwise we present a field. I've also added the concept of a field presenter, which allows us to present email addresses as linked.

There's also some improvements to testing, so we don't get caught out by whitespace in resulting HTML