### PR TITLE
(CM-51) Use `deep_symbolize_keys` when initializing a block's details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 0.5.2
+
+- Use `deep_symbolize_keys` when initializing a block's details  ([31](https://github.com/alphagov/govuk_content_block_tools/pull/31))
+
 ## 0.5.1
 
 - Update dependencies

--- a/lib/content_block_tools/content_block.rb
+++ b/lib/content_block_tools/content_block.rb
@@ -60,7 +60,7 @@ module ContentBlockTools
     end
 
     def details
-      to_h[:details].symbolize_keys
+      to_h[:details].deep_symbolize_keys
     end
   end
 end

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "0.5.1"
+  VERSION = "0.5.2"
 end

--- a/spec/content_block_tools/content_block_spec.rb
+++ b/spec/content_block_tools/content_block_spec.rb
@@ -23,10 +23,18 @@ RSpec.describe ContentBlockTools::ContentBlock do
   end
 
   describe ".details" do
-    let(:details) { { "foo" => "bar" } }
+    let(:details) do
+      {
+        "foo" => {
+          "bar" => {
+            "fizz" => "buzz",
+          },
+        },
+      }
+    end
 
     it "symbolizes the keys" do
-      expect(content_block.details).to eq({ foo: "bar" })
+      expect(content_block.details).to eq({ foo: { bar: { fizz: "buzz" } } })
     end
   end
 


### PR DESCRIPTION
When blocks are fetched from the database in Whitehall / Content Block Manager and passed to the initializer, the details have stringified keys, which means we get an error when fetching embedded details. Using `symbolize_keys` should get round it ordinarily, but because contact items are multiple levels deep, not all of the keys get symbolised. Using `deep_symbolize_keys` ensure all the keys are converted to symbols.