### PR TITLE
Support embedding nested blocks

### DIFF
--- a/lib/content_block_tools/presenters/contact_presenter.rb
+++ b/lib/content_block_tools/presenters/contact_presenter.rb
@@ -9,6 +9,10 @@ module ContentBlockTools
         email_address: ContentBlockTools::Presenters::FieldPresenters::Contact::EmailAddressPresenter,
       }.freeze
 
+      BLOCK_PRESENTERS = {
+        addresses: ContentBlockTools::Presenters::BlockPresenters::Contact::AddressPresenter,
+      }.freeze
+
       has_embedded_objects :addresses, :email_addresses, :telephones, :contact_forms
 
     private

--- a/spec/content_block_tools/presenters/base_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/base_presenter_spec.rb
@@ -140,4 +140,37 @@ RSpec.describe ContentBlockTools::Presenters::BasePresenter do
 
     expect(presenter_double).to have_received(:render)
   end
+
+  it "should render blocks with the base presenter" do
+    presenter_class = ContentBlockTools::Presenters::BlockPresenters::BasePresenter
+
+    render_response = "STUB_RESPONSE"
+    presenter_double = double(presenter_class, render: render_response)
+
+    content_block_with_nested_fields = ContentBlockTools::ContentBlock.new(
+      document_type: "something",
+      content_id:,
+      title: "My content block",
+      details: {
+        first_field: {
+          second_field: {
+            third_field: "hello world",
+          },
+        },
+      },
+      embed_code: "{{embed:content_block_contact:#{content_id}/first_field}}",
+    )
+
+    expect(presenter_class).to receive(:new).with({
+      second_field: {
+        third_field: "hello world",
+      },
+    }) {
+      presenter_double
+    }
+
+    described_class.new(content_block_with_nested_fields).render
+
+    expect(presenter_double).to have_received(:render)
+  end
 end

--- a/spec/content_block_tools/presenters/contact_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/contact_presenter_spec.rb
@@ -166,6 +166,25 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
         end
       end
     end
+
+    it "should render an address when embed code is provided" do
+      embed_code = "{{embed:content_block_contact:#{content_id}/addresses/some_address}}"
+
+      content_block = ContentBlockTools::ContentBlock.new(
+        document_type: "contact",
+        content_id:,
+        title: "My Contact",
+        details: { addresses: addresses, telephones: telephones },
+        embed_code:,
+      )
+
+      presenter = described_class.new(content_block)
+
+      expect(presenter.render).to have_tag("span", with: expected_wrapper_attributes.merge({ "data-embed-code" => embed_code, "data-document-type" => "contact" })) do
+        with_text "123 Fake Street,Springton,Missouri,TEST 123,USA"
+        with_tag "br", count: 4
+      end
+    end
   end
 
   describe "when contact forms are present" do


### PR DESCRIPTION
Before, if someone referenced a block that was embedded in a wider object (for example) an address embedded within a contact, then the object would be output as a plain hash (as if it were a string). This adds functionality to check if the content is a hash, and if it is, try and find a presenter to use to display the content.