### PR TITLE
Fix rendering telephone numbers and rendering individual nested fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 0.6.3
 
 - Fix rendering telephone numbers and rendering individual nested fields ([53](https://github.com/alphagov/govuk_content_block_tools/pull/53))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+- Fix rendering telephone numbers and rendering individual nested fields ([53](https://github.com/alphagov/govuk_content_block_tools/pull/53))
+
 ## 0.6.2
 
 - Handle UK call charges for a Contact block, remove links from telephone numbers ([51](https://github.com/alphagov/govuk_content_block_tools/pull/51))

--- a/lib/content_block_tools/presenters/base_presenter.rb
+++ b/lib/content_block_tools/presenters/base_presenter.rb
@@ -83,9 +83,15 @@ module ContentBlockTools
           embed_code_match = ContentBlockReference::EMBED_REGEX.match(content_block.embed_code)
           if embed_code_match.present?
             all_fields = embed_code_match[4]&.reverse&.chomp("/")&.reverse
-            all_fields&.split("/")&.map(&:to_sym)
+            all_fields&.split("/")&.map do |item|
+              is_number?(item) ? item.to_i : item.to_sym
+            end
           end
         end
+      end
+
+      def is_number?(item)
+        Float(item, exception: false)
       end
 
       def field_or_block_content

--- a/lib/content_block_tools/presenters/base_presenter.rb
+++ b/lib/content_block_tools/presenters/base_presenter.rb
@@ -113,7 +113,7 @@ module ContentBlockTools
       end
 
       def base_tag
-        field_names ? :span : self.class::BASE_TAG_TYPE
+        field_names ? field_or_block_presenter::BASE_TAG_TYPE : self.class::BASE_TAG_TYPE
       end
 
       def embedded_objects_of_type(type)

--- a/lib/content_block_tools/presenters/block_presenters/base_presenter.rb
+++ b/lib/content_block_tools/presenters/block_presenters/base_presenter.rb
@@ -4,6 +4,7 @@ module ContentBlockTools
       class BasePresenter
         include ActionView::Context
         include ActionView::Helpers::TextHelper
+        BASE_TAG_TYPE = :span
 
         attr_reader :item
 

--- a/lib/content_block_tools/presenters/block_presenters/contact/telephone_presenter.rb
+++ b/lib/content_block_tools/presenters/block_presenters/contact/telephone_presenter.rb
@@ -3,6 +3,8 @@ module ContentBlockTools
     module BlockPresenters
       module Contact
         class TelephonePresenter < ContentBlockTools::Presenters::BlockPresenters::BasePresenter
+          BASE_TAG_TYPE = :div
+
           def render
             content_tag(:div, class: "govuk-body") do
               concat number_list

--- a/lib/content_block_tools/presenters/block_presenters/contact/telephone_presenter.rb
+++ b/lib/content_block_tools/presenters/block_presenters/contact/telephone_presenter.rb
@@ -13,7 +13,7 @@ module ContentBlockTools
           end
 
           def number_list
-            content_tag(:ul, class: "govuk-!-padding-0 govuk-!-margin-0", style: "list-style: none;") do
+            content_tag(:ul, class: "govuk-!-padding-0 govuk-!-margin-0 govuk-list") do
               item[:telephone_numbers].each do |number|
                 concat number_list_item(number)
               end

--- a/lib/content_block_tools/presenters/field_presenters/base_presenter.rb
+++ b/lib/content_block_tools/presenters/field_presenters/base_presenter.rb
@@ -4,6 +4,7 @@ module ContentBlockTools
       class BasePresenter
         include ActionView::Context
         include ActionView::Helpers::TagHelper
+        BASE_TAG_TYPE = :span
 
         attr_reader :field
 

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "0.6.2"
+  VERSION = "0.6.3"
 end

--- a/spec/content_block_tools/presenters/block_presenters/contact/telephone_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/block_presenters/contact/telephone_presenter_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::Telephon
     presenter = described_class.new(phone_number)
 
     expect(presenter.render).to have_tag("div", with: { class: "govuk-body" }) do
-      with_tag("ul", with: { style: "list-style: none;" }) do
+      with_tag("ul", with: { class: "govuk-list" }) do
         with_tag("li", text: "Office: 1234")
         without_tag("a", text: "Find out about call charges", with: { href: "https://www.gov.uk/call-charges", class: "govuk-link" })
       end

--- a/spec/content_block_tools/presenters/contact_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/contact_presenter_spec.rb
@@ -154,6 +154,26 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
         end
       end
     end
+
+    it "should render an individual telephone number when a reference to the number is provided" do
+      embed_code = "{{embed:content_block_contact:#{content_id}/telephones/foo/telephone_numbers/0/telephone_number}}"
+
+      content_block = ContentBlockTools::ContentBlock.new(
+        document_type: "contact",
+        content_id:,
+        title: "My Contact",
+        details: { addresses: addresses, telephones: telephones },
+        embed_code:,
+      )
+
+      presenter = described_class.new(content_block)
+
+      expect(presenter.render).to have_tag("span",
+                                           with: expected_wrapper_attributes.merge(
+                                             { "data-embed-code" => embed_code, "data-document-type" => "contact" },
+                                           ),
+                                           text: "0891 50 50 50")
+    end
   end
 
   describe "when addresses are present" do

--- a/spec/content_block_tools/presenters/contact_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/contact_presenter_spec.rb
@@ -134,6 +134,26 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
         end
       end
     end
+
+    it "should render a telephone number when embed code is provided" do
+      embed_code = "{{embed:content_block_contact:#{content_id}/telephones/foo}}"
+
+      content_block = ContentBlockTools::ContentBlock.new(
+        document_type: "contact",
+        content_id:,
+        title: "My Contact",
+        details: { addresses: addresses, telephones: telephones },
+        embed_code:,
+      )
+
+      presenter = described_class.new(content_block)
+
+      expect(presenter.render).to have_tag("div", with: expected_wrapper_attributes.merge({ "data-embed-code" => embed_code, "data-document-type" => "contact" })) do
+        with_tag("div", with: { class: "govuk-body" }) do
+          with_tag("li", text: "Telephone: 0891 50 50 50")
+        end
+      end
+    end
   end
 
   describe "when addresses are present" do


### PR DESCRIPTION
At the moment, when attempting to render a telephone number in isolation, the presenter renders a `div` inside a `span`, which is not valid HTML. This results in the HTML wrapped inside the enclosing `span` to be escaped and rendered as text. This is because when field names are provided, we automatically assume the content will be wrapped in a `span`

To get around this, we add `BASE_TAG_TYPE`s to the base Field and Block presenters. If `field_names` are present for an embed code, we fetch the `BASE_TAG_TYPE` from the presenter and use that.

In most cases, this will be a `span`, but we override this when rendering a telephone.

As part of this, I've also fixed the rendering of individual fields within a nested telephone number.

## Screenshots (from Whitehall preview)

### Before 

![image](https://github.com/user-attachments/assets/f36ae6cd-3641-4624-b19b-0a651ad10f4d)

### After

![image](https://github.com/user-attachments/assets/770d386b-2e5c-4c1a-b84d-aef0880e54b6)
