### PR TITLE
CM-185: UK Call Charges fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 0.6.4
 
-- Fix rendering of block when UK call charges are not shown
+- Fix rendering of block when UK call charges are not shown ([54](https://github.com/alphagov/govuk_content_block_tools/pull/54))
 
 ## 0.6.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+- Fix rendering of block when UK call charges are not shown
+
 ## 0.6.3
 
 - Fix rendering telephone numbers and rendering individual nested fields ([53](https://github.com/alphagov/govuk_content_block_tools/pull/53))

--- a/lib/content_block_tools/presenters/block_presenters/contact/telephone_presenter.rb
+++ b/lib/content_block_tools/presenters/block_presenters/contact/telephone_presenter.rb
@@ -25,11 +25,13 @@ module ContentBlockTools
           end
 
           def call_charges_link
-            item[:show_uk_call_charges] == "true" && content_tag(:p, class: "govuk-!-margin-0") do
-              concat content_tag(:a,
-                                 "Find out about call charges",
-                                 class: "govuk-link",
-                                 href: "https://www.gov.uk/call-charges")
+            if item[:show_uk_call_charges] == "true"
+              content_tag(:p, class: "govuk-!-margin-0") do
+                concat content_tag(:a,
+                                   "Find out about call charges",
+                                   class: "govuk-link",
+                                   href: "https://www.gov.uk/call-charges")
+              end
             end
           end
         end

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "0.6.3"
+  VERSION = "0.6.4"
 end

--- a/spec/content_block_tools/presenters/block_presenters/contact/telephone_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/block_presenters/contact/telephone_presenter_spec.rb
@@ -22,8 +22,9 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::Telephon
     expect(presenter.render).to have_tag("div", with: { class: "govuk-body" }) do
       with_tag("ul", with: { class: "govuk-list" }) do
         with_tag("li", text: "Office: 1234")
-        without_tag("a", text: "Find out about call charges", with: { href: "https://www.gov.uk/call-charges", class: "govuk-link" })
       end
+      without_tag("a", text: "Find out about call charges", with: { href: "https://www.gov.uk/call-charges", class: "govuk-link" })
+      without_text("false")
     end
   end
 


### PR DESCRIPTION
- **fix UK Call Charges presentation**
Was previously showing `false` if it was set to false
- **Update CHANGELOG.md**

Before
![Screenshot 2025-06-25 at 15 24 01](https://github.com/user-attachments/assets/d5d98708-fbba-4af4-91f5-fbcafecb57db)

After
![Screenshot 2025-06-25 at 15 23 21](https://github.com/user-attachments/assets/8162b42b-138b-44e8-a2e4-522a2002a6c9)

---

This repo is owned by the content modelling team. Please let us know in #govuk-publishing-content-modelling-dev when you raise any PRs.
