### PR TITLE
(CM-221) Fix rendering of telephone blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 0.8.0
+
+- Add wrapper classes to contact sub-blocks ([57](https://github.com/alphagov/govuk_content_block_tools/pull/57))
+
 ## 0.7.0
 
 - Alter markup of contact ([55](https://github.com/alphagov/govuk_content_block_tools/pull/55))

--- a/lib/content_block_tools/presenters/base_presenter.rb
+++ b/lib/content_block_tools/presenters/base_presenter.rb
@@ -75,7 +75,7 @@ module ContentBlockTools
           return content_block.embed_code
         end
 
-        field_or_block_presenter.new(field_or_block_content).render
+        field_or_block_presenter.new(field_or_block_content, rendering_context: :field_names).render
       end
 
       def field_names

--- a/lib/content_block_tools/presenters/block_presenters/base_presenter.rb
+++ b/lib/content_block_tools/presenters/block_presenters/base_presenter.rb
@@ -8,7 +8,7 @@ module ContentBlockTools
 
         attr_reader :item
 
-        def initialize(item)
+        def initialize(item, **_args)
           @item = item
         end
 

--- a/lib/content_block_tools/presenters/block_presenters/contact/block_level_contact_item.rb
+++ b/lib/content_block_tools/presenters/block_presenters/contact/block_level_contact_item.rb
@@ -1,0 +1,30 @@
+module ContentBlockTools
+  module Presenters
+    module BlockPresenters
+      module Contact
+        module BlockLevelContactItem
+          BASE_TAG_TYPE = :div
+
+          def initialize(item, rendering_context: :block, **_args)
+            @item = item
+            @rendering_context = rendering_context
+          end
+
+          def wrapper(&block)
+            if @rendering_context == :field_names
+              content_tag(:div, class: "contact") do
+                content_tag(:div, class: "email-url-number") do
+                  yield block
+                end
+              end
+            else
+              content_tag(:div, class: "email-url-number") do
+                yield block
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/content_block_tools/presenters/block_presenters/contact/contact_form_presenter.rb
+++ b/lib/content_block_tools/presenters/block_presenters/contact/contact_form_presenter.rb
@@ -1,10 +1,14 @@
+require_relative "./block_level_contact_item"
+
 module ContentBlockTools
   module Presenters
     module BlockPresenters
       module Contact
         class ContactFormPresenter < ContentBlockTools::Presenters::BlockPresenters::BasePresenter
+          include ContentBlockTools::Presenters::BlockPresenters::Contact::BlockLevelContactItem
+
           def render
-            content_tag(:div, class: "email-url-number") do
+            wrapper do
               content_tag(:p) do
                 concat content_tag(:span, item[:title])
                 concat content_tag(:a,

--- a/lib/content_block_tools/presenters/block_presenters/contact/email_address_presenter.rb
+++ b/lib/content_block_tools/presenters/block_presenters/contact/email_address_presenter.rb
@@ -1,10 +1,14 @@
+require_relative "./block_level_contact_item"
+
 module ContentBlockTools
   module Presenters
     module BlockPresenters
       module Contact
         class EmailAddressPresenter < ContentBlockTools::Presenters::BlockPresenters::BasePresenter
+          include ContentBlockTools::Presenters::BlockPresenters::Contact::BlockLevelContactItem
+
           def render
-            content_tag(:div, class: "email-url-number") do
+            wrapper do
               content_tag(:p) do
                 concat content_tag(:span, item[:title])
                 concat content_tag(:a,

--- a/lib/content_block_tools/presenters/block_presenters/contact/telephone_presenter.rb
+++ b/lib/content_block_tools/presenters/block_presenters/contact/telephone_presenter.rb
@@ -1,12 +1,14 @@
+require_relative "./block_level_contact_item"
+
 module ContentBlockTools
   module Presenters
     module BlockPresenters
       module Contact
         class TelephonePresenter < ContentBlockTools::Presenters::BlockPresenters::BasePresenter
-          BASE_TAG_TYPE = :div
+          include ContentBlockTools::Presenters::BlockPresenters::Contact::BlockLevelContactItem
 
           def render
-            content_tag(:div, class: "email-url-number") do
+            wrapper do
               concat number_list
               concat opening_hours_list if item[:opening_hours].present?
               concat call_charges_link

--- a/lib/content_block_tools/presenters/contact_presenter.rb
+++ b/lib/content_block_tools/presenters/contact_presenter.rb
@@ -12,6 +12,8 @@ module ContentBlockTools
       BLOCK_PRESENTERS = {
         addresses: ContentBlockTools::Presenters::BlockPresenters::Contact::AddressPresenter,
         telephones: ContentBlockTools::Presenters::BlockPresenters::Contact::TelephonePresenter,
+        email_addresses: ContentBlockTools::Presenters::BlockPresenters::Contact::EmailAddressPresenter,
+        contact_forms: ContentBlockTools::Presenters::BlockPresenters::Contact::ContactFormPresenter,
       }.freeze
 
       has_embedded_objects :addresses, :email_addresses, :telephones, :contact_forms

--- a/lib/content_block_tools/presenters/field_presenters/base_presenter.rb
+++ b/lib/content_block_tools/presenters/field_presenters/base_presenter.rb
@@ -8,7 +8,7 @@ module ContentBlockTools
 
         attr_reader :field
 
-        def initialize(field)
+        def initialize(field, **_args)
           @field = field
         end
 

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "0.7.0"
+  VERSION = "0.8.0"
 end

--- a/spec/content_block_tools/presenters/base_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/base_presenter_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe ContentBlockTools::Presenters::BasePresenter do
       embed_code: "{{embed:content_block_contact:#{content_id}/first_field/second_field/third_field}}",
     )
 
-    expect(presenter_class).to receive(:new).with("hello world") {
+    expect(presenter_class).to receive(:new).with("hello world", rendering_context: :field_names) {
       presenter_double
     }
 
@@ -165,7 +165,7 @@ RSpec.describe ContentBlockTools::Presenters::BasePresenter do
       second_field: {
         third_field: "hello world",
       },
-    }) {
+    }, rendering_context: :field_names) {
       presenter_double
     }
 

--- a/spec/content_block_tools/presenters/block_presenters/contact/contact_form_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/block_presenters/contact/contact_form_presenter_spec.rb
@@ -14,4 +14,15 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::ContactF
       with_tag("a", text: "http://example.com", with: { href: "http://example.com", class: "url" })
     end
   end
+
+  describe "when rendering in the field_names context" do
+    it "should wrap in a contact class" do
+      presenter = described_class.new(contact_form, rendering_context: :field_names)
+      result = presenter.render
+
+      expect(result).to have_tag("div", with: { class: "contact" }) do
+        with_tag("div", with: { class: "email-url-number" })
+      end
+    end
+  end
 end

--- a/spec/content_block_tools/presenters/block_presenters/contact/email_address_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/block_presenters/contact/email_address_presenter_spec.rb
@@ -14,4 +14,15 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::EmailAdd
       with_tag("a", text: "foo@example.com", with: { href: "mailto:foo@example.com", class: "email" })
     end
   end
+
+  describe "when rendering in the field_names context" do
+    it "should wrap in a contact class" do
+      presenter = described_class.new(email_address, rendering_context: :field_names)
+      result = presenter.render
+
+      expect(result).to have_tag("div", with: { class: "contact" }) do
+        with_tag("div", with: { class: "email-url-number" })
+      end
+    end
+  end
 end

--- a/spec/content_block_tools/presenters/block_presenters/contact/telephone_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/block_presenters/contact/telephone_presenter_spec.rb
@@ -33,24 +33,28 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::Telephon
     presenter = described_class.new(phone_number)
     result = presenter.render
 
-    expect(result).to have_tag("ul") do
-      with_tag("li") do
-        with_tag(:span, text: "Office")
-        with_tag(:span, text: "1234", with: { class: "tel" })
+    expect(result).to_not have_tag("div", with: { class: "contact" })
+
+    expect(result).to have_tag("div", with: { class: "email-url-number" }) do
+      with_tag("ul") do
+        with_tag("li") do
+          with_tag(:span, text: "Office")
+          with_tag(:span, text: "1234", with: { class: "tel" })
+        end
+
+        with_tag("li") do
+          with_tag(:span, text: "International")
+          with_tag(:span, text: "5678", with: { class: "tel" })
+        end
       end
 
-      with_tag("li") do
-        with_tag(:span, text: "International")
-        with_tag(:span, text: "5678", with: { class: "tel" })
+      with_tag("ul") do
+        with_tag("li", text: "Monday to Friday, 9am to 5pm")
       end
-    end
 
-    expect(result).to have_tag("ul") do
-      with_tag("li", text: "Monday to Friday, 9am to 5pm")
+      without_tag("a", text: "Find out about call charges", with: { href: "https://www.gov.uk/call-charges" })
+      without_text("false")
     end
-
-    expect(result).not_to have_tag("a", text: "Find out about call charges", with: { href: "https://www.gov.uk/call-charges" })
-    expect(result).not_to have_tag("false")
   end
 
   describe "when there are no opening hours" do
@@ -62,38 +66,17 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::Telephon
 
       expect(result).to have_tag("ul", count: 1)
 
-      expect(result).to have_tag("ul") do
-        with_tag("li") do
-          with_tag(:span, text: "Office")
-          with_tag(:span, text: "1234", with: { class: "tel" })
-        end
+      expect(result).to have_tag("div", with: { class: "email-url-number" }) do
+        with_tag("ul") do
+          with_tag("li") do
+            with_tag(:span, text: "Office")
+            with_tag(:span, text: "1234", with: { class: "tel" })
+          end
 
-        with_tag("li") do
-          with_tag(:span, text: "International")
-          with_tag(:span, text: "5678", with: { class: "tel" })
-        end
-      end
-    end
-  end
-
-  describe "when opening hours is nil" do
-    let(:opening_hours) { nil }
-
-    it "should render successfully" do
-      presenter = described_class.new(phone_number)
-      result = presenter.render
-
-      expect(result).to have_tag("ul", count: 1)
-
-      expect(result).to have_tag("ul") do
-        with_tag("li") do
-          with_tag(:span, text: "Office")
-          with_tag(:span, text: "1234", with: { class: "tel" })
-        end
-
-        with_tag("li") do
-          with_tag(:span, text: "International")
-          with_tag(:span, text: "5678", with: { class: "tel" })
+          with_tag("li") do
+            with_tag(:span, text: "International")
+            with_tag(:span, text: "5678", with: { class: "tel" })
+          end
         end
       end
     end
@@ -108,15 +91,42 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::Telephon
 
       expect(result).to have_tag("ul", count: 1)
 
-      expect(result).to have_tag("ul") do
-        with_tag("li") do
-          with_tag(:span, text: "Office")
-          with_tag(:span, text: "1234", with: { class: "tel" })
-        end
+      expect(result).to have_tag("div", with: { class: "email-url-number" }) do
+        with_tag("ul") do
+          with_tag("li") do
+            with_tag(:span, text: "Office")
+            with_tag(:span, text: "1234", with: { class: "tel" })
+          end
 
-        with_tag("li") do
-          with_tag(:span, text: "International")
-          with_tag(:span, text: "5678", with: { class: "tel" })
+          with_tag("li") do
+            with_tag(:span, text: "International")
+            with_tag(:span, text: "5678", with: { class: "tel" })
+          end
+        end
+      end
+    end
+  end
+
+  describe "when opening hours is nil" do
+    let(:opening_hours) { nil }
+
+    it "should render successfully" do
+      presenter = described_class.new(phone_number)
+      result = presenter.render
+
+      expect(result).to have_tag("ul", count: 1)
+
+      expect(result).to have_tag("div", with: { class: "email-url-number" }) do
+        with_tag("ul") do
+          with_tag("li") do
+            with_tag(:span, text: "Office")
+            with_tag(:span, text: "1234", with: { class: "tel" })
+          end
+
+          with_tag("li") do
+            with_tag(:span, text: "International")
+            with_tag(:span, text: "5678", with: { class: "tel" })
+          end
         end
       end
     end
@@ -132,6 +142,17 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::Telephon
 
       expect(result).to have_tag("p") do
         with_tag("a", text: "Find out about call charges", with: { href: "https://www.gov.uk/call-charges" })
+      end
+    end
+  end
+
+  describe "when rendering in the field_names context" do
+    it "should wrap in a contact class" do
+      presenter = described_class.new(phone_number, rendering_context: :field_names)
+      result = presenter.render
+
+      expect(result).to have_tag("div", with: { class: "contact" }) do
+        with_tag("div", with: { class: "email-url-number" })
       end
     end
   end

--- a/spec/content_block_tools/presenters/contact_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/contact_presenter_spec.rb
@@ -78,7 +78,32 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
       end
     end
 
-    it "should render an email address when embed code is provided" do
+    it "should render an email address block when embed code is provided" do
+      embed_code = "{{embed:content_block_contact:#{content_id}/email_addresses/foo}}"
+
+      content_block = ContentBlockTools::ContentBlock.new(
+        document_type: "contact",
+        content_id:,
+        title: "My Contact",
+        details: { email_addresses: email_addresses, telephones: telephones },
+        embed_code:,
+      )
+
+      presenter = described_class.new(content_block)
+
+      expect(presenter.render).to have_tag("div", with: expected_wrapper_attributes.merge({ "data-embed-code" => embed_code })) do
+        with_tag("div", with: { class: "contact" }) do
+          with_tag("div", with: { class: "email-url-number" }) do
+            with_tag("p") do
+              with_tag("span", text: "Some email address")
+              with_tag("a", text: "foo@example.com", with: { href: "mailto:foo@example.com" })
+            end
+          end
+        end
+      end
+    end
+
+    it "should render an individual email address when embed code is provided" do
       embed_code = "{{embed:content_block_contact:#{content_id}/email_addresses/foo/email_address}}"
 
       content_block = ContentBlockTools::ContentBlock.new(
@@ -184,10 +209,14 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
       presenter = described_class.new(content_block)
 
       expect(presenter.render).to have_tag("div", with: expected_wrapper_attributes.merge({ "data-embed-code" => embed_code, "data-document-type" => "contact" })) do
-        with_tag("ul") do
-          with_tag("li") do
-            with_tag("span", text: "Telephone")
-            with_tag("span", text: "0891 50 50 50", with: { class: "tel" })
+        with_tag("div", with: { class: "contact" }) do
+          with_tag("div", with: { class: "email-url-number" }) do
+            with_tag("ul") do
+              with_tag("li") do
+                with_tag("span", text: "Telephone")
+                with_tag("span", text: "0891 50 50 50", with: { class: "tel" })
+              end
+            end
           end
         end
       end
@@ -309,6 +338,31 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
                 with_tag("span", text: "Some contact form")
                 with_tag("a", text: "http://example.com", with: { href: "http://example.com" })
               end
+            end
+          end
+        end
+      end
+    end
+
+    it "should render a contact form block when an embed code is provided" do
+      embed_code = "{{embed:content_block_contact:#{content_id}/contact_forms/foo}}"
+
+      content_block = ContentBlockTools::ContentBlock.new(
+        document_type: "contact",
+        content_id:,
+        title: "My Contact",
+        details: { contact_forms: contact_forms, telephones: telephones },
+        embed_code:,
+      )
+
+      presenter = described_class.new(content_block)
+
+      expect(presenter.render).to have_tag("div", with: expected_wrapper_attributes.merge({ "data-embed-code" => embed_code, "data-document-type" => "contact" })) do
+        with_tag("div", with: { class: "contact" }) do
+          with_tag("div", with: { class: "email-url-number" }) do
+            with_tag("p") do
+              with_tag("span", text: "Some contact form")
+              with_tag("a", text: "http://example.com", with: { href: "http://example.com" })
             end
           end
         end


### PR DESCRIPTION
This adds a `contact` class wrapper to block level items in contacts, which (in combination with https://github.com/alphagov/govuk_publishing_components/pull/4906) fixes the rendering of the telephone blocks

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/1395f043-87f5-4af7-b695-55a77e31faca)

### After

![image](https://github.com/user-attachments/assets/cd40771a-e661-44ee-b804-61276ebe53d5)