### PR TITLE
(CM-231) Make title rendering consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 0.10.0
+
+- Add content block titles to individual contact blocks ([60](https://github.com/alphagov/govuk_content_block_tools/pull/60))
+- Render title and description within telephone blocks ([60](https://github.com/alphagov/govuk_content_block_tools/pull/60))
+
 ## 0.9.0
 
 - Render addresses within a `contact` div ([58](https://github.com/alphagov/govuk_content_block_tools/pull/58))

--- a/content_block_tools.gemspec
+++ b/content_block_tools.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-govuk", "5.1.15"
 
   spec.add_dependency "actionview", ">= 6"
+  spec.add_dependency "govspeak", "10.4.1"
 end

--- a/lib/content_block_tools.rb
+++ b/lib/content_block_tools.rb
@@ -2,6 +2,9 @@
 
 require "action_view"
 require "uri"
+require "govspeak"
+
+require "content_block_tools/helpers/govspeak"
 
 require "content_block_tools/presenters/field_presenters/base_presenter"
 require "content_block_tools/presenters/field_presenters/contact/email_address_presenter"

--- a/lib/content_block_tools/helpers/govspeak.rb
+++ b/lib/content_block_tools/helpers/govspeak.rb
@@ -1,0 +1,10 @@
+module ContentBlockTools
+  module Govspeak
+    def render_govspeak(body, root_class: nil)
+      html = ::Govspeak::Document.new(body).to_html
+      Nokogiri::HTML.fragment(html).tap { |fragment|
+        fragment.children[0].add_class(root_class) if root_class
+      }.to_s.html_safe
+    end
+  end
+end

--- a/lib/content_block_tools/presenters/base_presenter.rb
+++ b/lib/content_block_tools/presenters/base_presenter.rb
@@ -75,7 +75,7 @@ module ContentBlockTools
           return content_block.embed_code
         end
 
-        field_or_block_presenter.new(field_or_block_content, rendering_context: :field_names).render
+        field_or_block_presenter.new(field_or_block_content, rendering_context: :field_names, content_block:).render
       end
 
       def field_names

--- a/lib/content_block_tools/presenters/block_presenters/base_presenter.rb
+++ b/lib/content_block_tools/presenters/block_presenters/base_presenter.rb
@@ -4,6 +4,8 @@ module ContentBlockTools
       class BasePresenter
         include ActionView::Context
         include ActionView::Helpers::TextHelper
+        include ContentBlockTools::Govspeak
+
         BASE_TAG_TYPE = :span
 
         attr_reader :item

--- a/lib/content_block_tools/presenters/block_presenters/contact/address_presenter.rb
+++ b/lib/content_block_tools/presenters/block_presenters/contact/address_presenter.rb
@@ -19,16 +19,6 @@ module ContentBlockTools
             end
           end
 
-          def wrapper(&block)
-            if @rendering_context == :field_names
-              content_tag(:div, class: "contact") do
-                yield block
-              end
-            else
-              yield block
-            end
-          end
-
           def class_for_field_name(field_name)
             {
               street_address: "street-address",

--- a/lib/content_block_tools/presenters/block_presenters/contact/block_level_contact_item.rb
+++ b/lib/content_block_tools/presenters/block_presenters/contact/block_level_contact_item.rb
@@ -5,8 +5,9 @@ module ContentBlockTools
         module BlockLevelContactItem
           BASE_TAG_TYPE = :div
 
-          def initialize(item, rendering_context: :block, **_args)
+          def initialize(item, content_block:, rendering_context: :block, **_args)
             @item = item
+            @content_block = content_block
             @rendering_context = rendering_context
           end
 

--- a/lib/content_block_tools/presenters/block_presenters/contact/block_level_contact_item.rb
+++ b/lib/content_block_tools/presenters/block_presenters/contact/block_level_contact_item.rb
@@ -14,11 +14,18 @@ module ContentBlockTools
           def wrapper(&block)
             if @rendering_context == :field_names
               content_tag(:div, class: "contact") do
-                yield block
+                concat title
+                concat yield block
               end
             else
               yield block
             end
+          end
+
+          def title
+            content_tag(:p,
+                        @content_block.title,
+                        class: "govuk-!-margin-bottom-3")
           end
         end
       end

--- a/lib/content_block_tools/presenters/block_presenters/contact/telephone_presenter.rb
+++ b/lib/content_block_tools/presenters/block_presenters/contact/telephone_presenter.rb
@@ -10,11 +10,33 @@ module ContentBlockTools
           def render
             wrapper do
               content_tag(:div, class: "email-url-number") do
+                concat title_and_description
                 concat number_list
                 concat opening_hours_list if item[:opening_hours].present?
                 concat call_charges_link
               end
             end
+          end
+
+          def title_and_description
+            items = [
+              (item_title if item[:title].present?),
+              (description if item[:description].present?),
+            ].compact
+
+            if items.any?
+              content_tag(:div, class: "govuk-!-margin-bottom-3") do
+                concat items.join("").html_safe
+              end
+            end
+          end
+
+          def item_title
+            content_tag(:p, item[:title], { class: "govuk-!-margin-bottom-0" })
+          end
+
+          def description
+            render_govspeak(item[:description], root_class: "govuk-!-margin-top-1 govuk-!-margin-bottom-0")
           end
 
           def number_list

--- a/lib/content_block_tools/presenters/contact_presenter.rb
+++ b/lib/content_block_tools/presenters/contact_presenter.rb
@@ -27,7 +27,7 @@ module ContentBlockTools
               concat content_tag(:p, content_block.title, class: "fn org")
               embedded_objects.each do |object|
                 items = send(object)
-                concat(items.map { |item| presenter_for_object_type(object).new(item).render }.join.html_safe)
+                concat(items.map { |item| presenter_for_object_type(object).new(item, content_block:).render }.join.html_safe)
               end
             end
           end

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "0.9.0"
+  VERSION = "0.10.0"
 end

--- a/spec/content_block_tools/helpers/govspeak_spec.rb
+++ b/spec/content_block_tools/helpers/govspeak_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe ContentBlockTools::Govspeak do
+  include ContentBlockTools::Govspeak
+
+  describe "#render_govspeak" do
+    let(:govspeak) { "Some govspeak **here**" }
+
+    context "when a root_class is not provided" do
+      it "renders Govspeak" do
+        expect(render_govspeak(govspeak)).to eq("<p>Some govspeak <strong>here</strong></p>\n")
+      end
+    end
+
+    context "when a root_class is provided" do
+      it "renders Govspeak with a root class" do
+        expect(render_govspeak(govspeak, root_class: "foo")).to eq("<p class=\"foo\">Some govspeak <strong>here</strong></p>\n")
+      end
+    end
+  end
+end

--- a/spec/content_block_tools/presenters/base_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/base_presenter_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe ContentBlockTools::Presenters::BasePresenter do
       embed_code: "{{embed:content_block_contact:#{content_id}/first_field/second_field/third_field}}",
     )
 
-    expect(presenter_class).to receive(:new).with("hello world", rendering_context: :field_names) {
+    expect(presenter_class).to receive(:new).with("hello world", rendering_context: :field_names, content_block: content_block_with_nested_fields) {
       presenter_double
     }
 
@@ -165,7 +165,7 @@ RSpec.describe ContentBlockTools::Presenters::BasePresenter do
       second_field: {
         third_field: "hello world",
       },
-    }, rendering_context: :field_names) {
+    }, rendering_context: :field_names, content_block: content_block_with_nested_fields) {
       presenter_double
     }
 

--- a/spec/content_block_tools/presenters/block_presenters/contact/address_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/block_presenters/contact/address_presenter_spec.rb
@@ -33,10 +33,11 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::AddressP
     end
   end
 
-  it "should render successfully with field_names rendering context" do
+  it "should render successfully with field_names rendering context with the content block's title" do
     presenter = described_class.new(address, rendering_context: :field_names, content_block:)
 
     expect(presenter.render).to have_tag(:div, with: { class: "contact" }) do
+      with_tag("p", text: content_block.title, with: { class: 'govuk-\!-margin-bottom-3' })
       with_tag(:p) do
         with_tag(:span, text: "123 Fake Street", with: { class: "street-address" })
         with_tag(:span, text: "Springton", with: { class: "locality" })

--- a/spec/content_block_tools/presenters/block_presenters/contact/address_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/block_presenters/contact/address_presenter_spec.rb
@@ -1,4 +1,14 @@
 RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::AddressPresenter do
+  let(:content_block) do
+    ContentBlockTools::ContentBlock.new(
+      document_type: "something",
+      title: "My content block",
+      details: {},
+      content_id: 123,
+      embed_code: "something",
+    )
+  end
+
   let(:address) do
     {
       "title": "Some address",
@@ -11,7 +21,7 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::AddressP
   end
 
   it "should render successfully" do
-    presenter = described_class.new(address)
+    presenter = described_class.new(address, content_block:)
 
     expect(presenter.render).to have_tag(:p) do
       with_tag(:span, text: "123 Fake Street", with: { class: "street-address" })
@@ -24,7 +34,7 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::AddressP
   end
 
   it "should render successfully with field_names rendering context" do
-    presenter = described_class.new(address, rendering_context: :field_names)
+    presenter = described_class.new(address, rendering_context: :field_names, content_block:)
 
     expect(presenter.render).to have_tag(:div, with: { class: "contact" }) do
       with_tag(:p) do
@@ -51,7 +61,7 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::AddressP
     end
 
     it "should ignore the missing fields" do
-      presenter = described_class.new(address)
+      presenter = described_class.new(address, content_block:)
 
       expect(presenter.render).to have_tag(:p) do
         with_tag(:span, text: "123 Fake Street", with: { class: "street-address" })

--- a/spec/content_block_tools/presenters/block_presenters/contact/contact_form_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/block_presenters/contact/contact_form_presenter_spec.rb
@@ -1,4 +1,14 @@
 RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::ContactFormPresenter do
+  let(:content_block) do
+    ContentBlockTools::ContentBlock.new(
+      document_type: "something",
+      title: "My content block",
+      details: {},
+      content_id: 123,
+      embed_code: "something",
+    )
+  end
+
   let(:contact_form) do
     {
       "title": "Contact us",
@@ -7,7 +17,7 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::ContactF
   end
 
   it "should render successfully" do
-    presenter = described_class.new(contact_form)
+    presenter = described_class.new(contact_form, content_block:)
 
     expect(presenter.render).to have_tag("p") do
       with_tag("span", text: "Contact us")
@@ -17,7 +27,7 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::ContactF
 
   describe "when rendering in the field_names context" do
     it "should wrap in a contact class" do
-      presenter = described_class.new(contact_form, rendering_context: :field_names)
+      presenter = described_class.new(contact_form, rendering_context: :field_names, content_block:)
       result = presenter.render
 
       expect(result).to have_tag("div", with: { class: "contact" }) do

--- a/spec/content_block_tools/presenters/block_presenters/contact/contact_form_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/block_presenters/contact/contact_form_presenter_spec.rb
@@ -26,11 +26,12 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::ContactF
   end
 
   describe "when rendering in the field_names context" do
-    it "should wrap in a contact class" do
+    it "should wrap in a contact class with the content block's title" do
       presenter = described_class.new(contact_form, rendering_context: :field_names, content_block:)
       result = presenter.render
 
       expect(result).to have_tag("div", with: { class: "contact" }) do
+        with_tag("p", text: content_block.title, with: { class: 'govuk-\!-margin-bottom-3' })
         with_tag("div", with: { class: "email-url-number" })
       end
     end

--- a/spec/content_block_tools/presenters/block_presenters/contact/email_address_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/block_presenters/contact/email_address_presenter_spec.rb
@@ -1,4 +1,14 @@
 RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::EmailAddressPresenter do
+  let(:content_block) do
+    ContentBlockTools::ContentBlock.new(
+      document_type: "something",
+      title: "My content block",
+      details: {},
+      content_id: 123,
+      embed_code: "something",
+    )
+  end
+
   let(:email_address) do
     {
       "title": "Some email address",
@@ -7,7 +17,7 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::EmailAdd
   end
 
   it "should render successfully" do
-    presenter = described_class.new(email_address)
+    presenter = described_class.new(email_address, content_block:)
 
     expect(presenter.render).to have_tag("p") do
       with_tag("span", text: "Some email address")
@@ -18,6 +28,7 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::EmailAdd
   describe "when rendering in the field_names context" do
     it "should wrap in a contact class" do
       presenter = described_class.new(email_address, rendering_context: :field_names)
+      presenter = described_class.new(email_address, rendering_context: :field_names, content_block:)
       result = presenter.render
 
       expect(result).to have_tag("div", with: { class: "contact" }) do

--- a/spec/content_block_tools/presenters/block_presenters/contact/email_address_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/block_presenters/contact/email_address_presenter_spec.rb
@@ -26,12 +26,12 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::EmailAdd
   end
 
   describe "when rendering in the field_names context" do
-    it "should wrap in a contact class" do
-      presenter = described_class.new(email_address, rendering_context: :field_names)
+    it "should wrap in a contact class with the content block's title" do
       presenter = described_class.new(email_address, rendering_context: :field_names, content_block:)
       result = presenter.render
 
       expect(result).to have_tag("div", with: { class: "contact" }) do
+        with_tag("p", text: content_block.title, with: { class: 'govuk-\!-margin-bottom-3' })
         with_tag("div", with: { class: "email-url-number" })
       end
     end

--- a/spec/content_block_tools/presenters/block_presenters/contact/telephone_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/block_presenters/contact/telephone_presenter_spec.rb
@@ -1,4 +1,14 @@
 RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::TelephonePresenter do
+  let(:content_block) do
+    ContentBlockTools::ContentBlock.new(
+      document_type: "something",
+      title: "My content block",
+      details: {},
+      content_id: 123,
+      embed_code: "something",
+    )
+  end
+
   let(:show_uk_call_charges) { "false" }
   let(:opening_hours) do
     [
@@ -30,7 +40,7 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::Telephon
   end
 
   it "should render successfully" do
-    presenter = described_class.new(phone_number)
+    presenter = described_class.new(phone_number, content_block:)
     result = presenter.render
 
     expect(result).to_not have_tag("div", with: { class: "contact" })
@@ -61,7 +71,7 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::Telephon
     let(:opening_hours) { [] }
 
     it "should render successfully" do
-      presenter = described_class.new(phone_number)
+      presenter = described_class.new(phone_number, content_block:)
       result = presenter.render
 
       expect(result).to have_tag("ul", count: 1)
@@ -86,7 +96,7 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::Telephon
     let(:opening_hours) { nil }
 
     it "should render successfully" do
-      presenter = described_class.new(phone_number)
+      presenter = described_class.new(phone_number, content_block:)
       result = presenter.render
 
       expect(result).to have_tag("ul", count: 1)
@@ -111,7 +121,7 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::Telephon
     let(:opening_hours) { nil }
 
     it "should render successfully" do
-      presenter = described_class.new(phone_number)
+      presenter = described_class.new(phone_number, content_block:)
       result = presenter.render
 
       expect(result).to have_tag("ul", count: 1)
@@ -136,7 +146,7 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::Telephon
     let(:show_uk_call_charges) { "true" }
 
     it "renders a link" do
-      presenter = described_class.new(phone_number)
+      presenter = described_class.new(phone_number, content_block:)
 
       result = presenter.render
 
@@ -148,7 +158,7 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::Telephon
 
   describe "when rendering in the field_names context" do
     it "should wrap in a contact class" do
-      presenter = described_class.new(phone_number, rendering_context: :field_names)
+      presenter = described_class.new(phone_number, rendering_context: :field_names, content_block:)
       result = presenter.render
 
       expect(result).to have_tag("div", with: { class: "contact" }) do

--- a/spec/content_block_tools/presenters/block_presenters/contact/telephone_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/block_presenters/contact/telephone_presenter_spec.rb
@@ -157,11 +157,12 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::Telephon
   end
 
   describe "when rendering in the field_names context" do
-    it "should wrap in a contact class" do
+    it "should wrap in a contact class with the content block's title" do
       presenter = described_class.new(phone_number, rendering_context: :field_names, content_block:)
       result = presenter.render
 
       expect(result).to have_tag("div", with: { class: "contact" }) do
+        with_tag("p", text: content_block.title, with: { class: 'govuk-\!-margin-bottom-3' })
         with_tag("div", with: { class: "email-url-number" })
       end
     end

--- a/spec/content_block_tools/presenters/block_presenters/contact/telephone_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/block_presenters/contact/telephone_presenter_spec.rb
@@ -20,10 +20,12 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::Telephon
       },
     ]
   end
+  let(:description) { nil }
 
   let(:phone_number) do
     {
       "title": "Some phone number",
+      "description": description,
       "telephone_numbers": [
         {
           "label": "Office",
@@ -46,6 +48,10 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::Telephon
     expect(result).to_not have_tag("div", with: { class: "contact" })
 
     expect(result).to have_tag("div", with: { class: "email-url-number" }) do
+      with_tag("div", with: { class: 'govuk-\!-margin-bottom-3' }) do
+        with_tag(:p, text: phone_number[:title], with: { class: 'govuk-\!-margin-bottom-0' })
+      end
+
       with_tag("ul") do
         with_tag("li") do
           with_tag(:span, text: "Office")
@@ -152,6 +158,29 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::Telephon
 
       expect(result).to have_tag("p") do
         with_tag("a", text: "Find out about call charges", with: { href: "https://www.gov.uk/call-charges" })
+      end
+    end
+  end
+
+  describe "when a description is present" do
+    let(:description) { "Some description" }
+
+    it "should include the description" do
+      presenter = described_class.new(phone_number, content_block:)
+
+      expect(presenter).to receive(:render_govspeak)
+                             .with(description, root_class: "govuk-!-margin-top-1 govuk-!-margin-bottom-0")
+                             .and_call_original
+
+      result = presenter.render
+
+      expect(result).to_not have_tag("div", with: { class: "contact" })
+
+      expect(result).to have_tag("div", with: { class: "email-url-number" }) do
+        with_tag("div", with: { class: 'govuk-\!-margin-bottom-3' }) do
+          with_tag(:p, text: phone_number[:title], with: { class: 'govuk-\!-margin-bottom-0' })
+          with_tag(:p, text: phone_number[:description], with: { class: 'govuk-\!-margin-top-1 govuk-\!-margin-bottom-0' })
+        end
       end
     end
   end


### PR DESCRIPTION
This updates the individual contact mode blocks to consistently show the parent block's title, as well as showing the telephone mode's title and description (rendered as Govspeak) within the telephone block.

I'm still not 100% happy with this approach, but this is consistent enough for us to get in front of users.