### PR TITLE
(CM-240) Replace special dashes with double/triple dashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 0.12.1
+
+- Fix when content block codes include special dashes ([64](https://github.com/alphagov/govuk_content_block_tools/pull/64))
+
 ## 0.12.0
 
 - Add missing fields for contact object ([62](https://github.com/alphagov/govuk_content_block_tools/pull/62))

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "0.12.0"
+  VERSION = "0.12.1"
 end

--- a/spec/content_block_tools/content_block_reference_spec.rb
+++ b/spec/content_block_tools/content_block_reference_spec.rb
@@ -181,5 +181,29 @@ RSpec.describe ContentBlockTools::ContentBlockReference do
         end
       end
     end
+
+    describe "when there are en or em dashes in the embed codes" do
+      let(:contact_alias) { "contact-alias–1" }
+      let(:content_block_pension_alias) { "email-address-alias—1" }
+
+      let(:document) do
+        "
+        {{embed:contact:#{contact_alias}}}
+        {{embed:content_block_pension:#{content_block_pension_alias}}}
+        "
+      end
+
+      it "replaces en or em dashes with the appropriate number of dashes" do
+        expect(result.count).to eq(2)
+
+        expect(result[0].document_type).to eq("contact")
+        expect(result[0].identifier).to eq("contact-alias--1")
+        expect(result[0].embed_code).to eq("{{embed:contact:contact-alias--1}}")
+
+        expect(result[1].document_type).to eq("content_block_pension")
+        expect(result[1].identifier).to eq("email-address-alias---1")
+        expect(result[1].embed_code).to eq("{{embed:content_block_pension:email-address-alias---1}}")
+      end
+    end
   end
 end


### PR DESCRIPTION
Kramdown (the markdown parses that Govspeak is based on) replaces double/triple dashes with en/em dashes. This can cause a problem if an embed code contains double or triple dashes (for example when there is a name collision for an identifier.

It seems the easiest way to combat this is scan the document for special dashes, then replace them with double or triple dashes when initializing the references. This should ensure the codes get found correctly.