### PR TITLE
Add escape character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 0.12.2
+
+- Add escape character to silence warnings ([65](https://github.com/alphagov/govuk_content_block_tools/pull/65))
+
 ## 0.12.1
 
 - Fix when content block codes include special dashes ([64](https://github.com/alphagov/govuk_content_block_tools/pull/64))

--- a/lib/content_block_tools/content_block_reference.rb
+++ b/lib/content_block_tools/content_block_reference.rb
@@ -32,7 +32,7 @@ module ContentBlockTools
     # The regex used to find UUIDs
     UUID_REGEX = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
     # The regex used to find content ID aliases
-    CONTENT_ID_ALIAS_REGEX = /[a-z0-9-–—]+/
+    CONTENT_ID_ALIAS_REGEX = /[a-z0-9\-–—]+/
     # The regex to find optional field names after the UUID, begins with '/'
     FIELD_REGEX = /(\/[a-z0-9_\-–—\/]*)?/
     # The regex used when scanning a document using {ContentBlockTools::ContentBlockReference.find_all_in_document}

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "0.12.1"
+  VERSION = "0.12.2"
 end


### PR DESCRIPTION
At the moment, we’re getting a warning in the logs which is quite noisy:

```bash
/usr/local/bundle/ruby/3.3.0/gems/content_block_tools-0.12.1/lib/content_block_tools/content_block_reference.rb: warning: character class has '-' without escape: /[a-z0-9-–—]+/
/usr/local/bundle/ruby/3.3.0/gems/content_block_tools-0.12.1/lib/content_block_tools/content_block_reference.rb:39: warning: character class has '-' without escape
```
Before we added the en and em dashes, we weren’t getting the warning as the dash was the last character in the sequence. Adding the escape character ensures the regex still works, but gets rid of the noise in the logs.