### PR TITLE
(CM-182) Rename Contact Form to Contact Link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 0.13.0
+
+- Rename Contact Form to Contact Link ([70](https://github.com/alphagov/govuk_content_block_tools/pull/70))
+
 ## 0.12.3
 
 - Only replace special dashes in identifiers ([69](https://github.com/alphagov/govuk_content_block_tools/pull/69))

--- a/lib/content_block_tools.rb
+++ b/lib/content_block_tools.rb
@@ -11,7 +11,7 @@ require "content_block_tools/presenters/field_presenters/contact/email_address_p
 
 require "content_block_tools/presenters/block_presenters/base_presenter"
 require "content_block_tools/presenters/block_presenters/contact/address_presenter"
-require "content_block_tools/presenters/block_presenters/contact/contact_form_presenter"
+require "content_block_tools/presenters/block_presenters/contact/contact_link_presenter"
 require "content_block_tools/presenters/block_presenters/contact/email_address_presenter"
 require "content_block_tools/presenters/block_presenters/contact/telephone_presenter"
 

--- a/lib/content_block_tools/presenters/block_presenters/contact/contact_link_presenter.rb
+++ b/lib/content_block_tools/presenters/block_presenters/contact/contact_link_presenter.rb
@@ -4,7 +4,7 @@ module ContentBlockTools
   module Presenters
     module BlockPresenters
       module Contact
-        class ContactFormPresenter < ContentBlockTools::Presenters::BlockPresenters::BasePresenter
+        class ContactLinkPresenter < ContentBlockTools::Presenters::BlockPresenters::BasePresenter
           include ContentBlockTools::Presenters::BlockPresenters::Contact::BlockLevelContactItem
 
           def render

--- a/lib/content_block_tools/presenters/contact_presenter.rb
+++ b/lib/content_block_tools/presenters/contact_presenter.rb
@@ -14,10 +14,10 @@ module ContentBlockTools
         addresses: ContentBlockTools::Presenters::BlockPresenters::Contact::AddressPresenter,
         telephones: ContentBlockTools::Presenters::BlockPresenters::Contact::TelephonePresenter,
         email_addresses: ContentBlockTools::Presenters::BlockPresenters::Contact::EmailAddressPresenter,
-        contact_forms: ContentBlockTools::Presenters::BlockPresenters::Contact::ContactFormPresenter,
+        contact_links: ContentBlockTools::Presenters::BlockPresenters::Contact::ContactLinkPresenter,
       }.freeze
 
-      has_embedded_objects :addresses, :email_addresses, :telephones, :contact_forms
+      has_embedded_objects :addresses, :email_addresses, :telephones, :contact_links
 
     private
 

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "0.12.3"
+  VERSION = "0.13.0"
 end

--- a/spec/content_block_tools/presenters/block_presenters/contact/contact_link_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/block_presenters/contact/contact_link_presenter_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::ContactFormPresenter do
+RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::ContactLinkPresenter do
   let(:content_block) do
     ContentBlockTools::ContentBlock.new(
       document_type: "something",
@@ -9,7 +9,7 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::ContactF
     )
   end
 
-  let(:contact_form) do
+  let(:contact_link) do
     {
       "title": "Contact us",
       "url": "http://example.com",
@@ -17,7 +17,7 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::ContactF
   end
 
   it "should render successfully" do
-    presenter = described_class.new(contact_form, content_block:)
+    presenter = described_class.new(contact_link, content_block:)
 
     expect(presenter.render).to have_tag("p") do
       with_tag("span", text: "Contact us")
@@ -27,7 +27,7 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::ContactF
 
   describe "when rendering in the field_names context" do
     it "should wrap in a contact class with the content block's title" do
-      presenter = described_class.new(contact_form, rendering_context: :field_names, content_block:)
+      presenter = described_class.new(contact_link, rendering_context: :field_names, content_block:)
       result = presenter.render
 
       expect(result).to have_tag("div", with: { class: "contact" }) do

--- a/spec/content_block_tools/presenters/contact_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/contact_presenter_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
   let(:email_addresses) { {} }
   let(:telephones) { {} }
   let(:addresses) { {} }
-  let(:contact_forms) { {} }
+  let(:contact_links) { {} }
   let(:description) { nil }
 
   let(:content_block) do
@@ -11,7 +11,7 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
       document_type: "contact",
       content_id:,
       title: "My Contact",
-      details: { email_addresses: email_addresses, telephones: telephones, addresses: addresses, contact_forms: contact_forms, description: },
+      details: { email_addresses: email_addresses, telephones: telephones, addresses: addresses, contact_links: contact_links, description: },
       embed_code: "something",
     )
   end
@@ -310,8 +310,8 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
     end
   end
 
-  describe "when contact forms are present" do
-    let(:contact_forms) do
+  describe "when contact links are present" do
+    let(:contact_links) do
       {
         "foo": {
           "title": "Some contact form",
@@ -320,10 +320,10 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
       }
     end
 
-    it "should return the contact forms" do
+    it "should return the contact links" do
       presenter = described_class.new(content_block)
 
-      expect(presenter.contact_forms).to eq([{
+      expect(presenter.contact_links).to eq([{
         "title": "Some contact form",
         "url": "http://example.com",
       }])
@@ -348,13 +348,13 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
     end
 
     it "should render a contact form block when an embed code is provided" do
-      embed_code = "{{embed:content_block_contact:#{content_id}/contact_forms/foo}}"
+      embed_code = "{{embed:content_block_contact:#{content_id}/contact_links/foo}}"
 
       content_block = ContentBlockTools::ContentBlock.new(
         document_type: "contact",
         content_id:,
         title: "My Contact",
-        details: { contact_forms: contact_forms, telephones: telephones },
+        details: { contact_links: contact_links, telephones: telephones },
         embed_code:,
       )
 


### PR DESCRIPTION
This matches up with the changes in https://github.com/alphagov/publishing-api/pull/3480