### PR TITLE
(CM 294) Update content block tools to display blocks as per the design system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,32 @@ jobs:
       - run: echo "All matrix tests have passed 🚀"
 
   publish:
-    needs: test_matrix
+    needs: test
+    runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' }}
     permissions:
       contents: write
-    uses: alphagov/govuk-infrastructure/.github/workflows/publish-rubygem.yml@main
-    with:
-      gem_name: content_block_tools
-    secrets:
-      GEM_HOST_API_KEY: ${{ secrets.ALPHAGOV_RUBYGEMS_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          rubygems: latest
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: lts/* # use the latest LTS release
+      - run: yarn install
+      - env:
+          GEM_HOST_API_KEY: ${{ secrets.ALPHAGOV_RUBYGEMS_API_KEY }}
+        run: |
+          VERSION=$(ruby -e "puts eval(File.read('content_block_tools.gemspec')).version")
+          GEM_VERSION=$(gem list --exact --remote content_block_tools)
+          
+          if [ "${GEM_VERSION}" != "content_block_tools (${VERSION})" ]; then
+            gem build content_block_tools.gemspec
+            gem push "content_block_tools-${VERSION}.gem"
+          fi
+          
+          if ! git ls-remote --tags --exit-code origin v"${VERSION}"; then
+            git tag v"${VERSION}"
+            git push --tags
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ lib/.DS_Store
 spec/.DS_Store
 lib/content_block_tools/.DS_Store
 spec/content_block_tools/.DS_Store
+/node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 1.0.0
+
+- Add portable styling to the gem ([76](https://github.com/alphagov/govuk_content_block_tools/pull/76))
+- Update contact blocks to match design system ([76](https://github.com/alphagov/govuk_content_block_tools/pull/76))
+
 ## 0.17.0
 
 - Use recipient field in address ([75](https://github.com/alphagov/govuk_content_block_tools/pull/75))

--- a/app/assets/stylesheets/blocks/_contact.scss
+++ b/app/assets/stylesheets/blocks/_contact.scss
@@ -1,0 +1,13 @@
+@import "govuk/core/typography";
+
+.content-block--contact {
+  .content-block {
+    &__title {
+      @extend %govuk-heading-m;
+    }
+
+    &__subtitle {
+      @extend %govuk-heading-s;
+    }
+  }
+}

--- a/app/assets/stylesheets/content_block_tools.scss
+++ b/app/assets/stylesheets/content_block_tools.scss
@@ -1,0 +1,24 @@
+@import "govuk/core/lists";
+@import "govuk/core/typography";
+
+@import "blocks/contact";
+
+.content-block {
+  &__body {
+    @extend %govuk-body-m;
+  }
+
+  ul#{&}__list {
+    @extend %govuk-list;
+    margin-left: 0;
+
+    & > li {
+      list-style: none;
+      margin-bottom: govuk-spacing(1);
+    }
+  }
+
+  &__link {
+    @extend %govuk-link;
+  }
+}

--- a/lib/content_block_tools.rb
+++ b/lib/content_block_tools.rb
@@ -22,6 +22,8 @@ require "content_block_tools/presenters/pension_presenter"
 require "content_block_tools/content_block"
 require "content_block_tools/content_block_reference"
 
+require "content_block_tools/engine"
+
 require "content_block_tools/version"
 
 module ContentBlockTools
@@ -33,14 +35,6 @@ module ContentBlockTools
 
     def logger
       @logger ||= Logger.new($stdout)
-    end
-  end
-
-  if defined?(Rails::Railtie)
-    class Railtie < Rails::Railtie
-      initializer "content_block_tools.initialize_logger" do
-        ContentBlockTools.logger = Rails.logger
-      end
     end
   end
 end

--- a/lib/content_block_tools/engine.rb
+++ b/lib/content_block_tools/engine.rb
@@ -2,6 +2,13 @@ module ContentBlockTools
   class Engine < ::Rails::Engine
     isolate_namespace ContentBlockTools
 
+    initializer "content_block_tools.assets" do
+      Rails.application.config.assets.paths += %w[
+        app/assets/stylesheets
+        node_modules/govuk-frontend/dist/govuk/core
+      ]
+    end
+
     initializer "content_block_tools.initialize_logger" do
       ContentBlockTools.logger = Rails.logger
     end

--- a/lib/content_block_tools/engine.rb
+++ b/lib/content_block_tools/engine.rb
@@ -1,0 +1,9 @@
+module ContentBlockTools
+  class Engine < ::Rails::Engine
+    isolate_namespace ContentBlockTools
+
+    initializer "content_block_tools.initialize_logger" do
+      ContentBlockTools.logger = Rails.logger
+    end
+  end
+end

--- a/lib/content_block_tools/presenters/block_presenters/contact/address_presenter.rb
+++ b/lib/content_block_tools/presenters/block_presenters/contact/address_presenter.rb
@@ -11,7 +11,7 @@ module ContentBlockTools
             wrapper do
               output = []
 
-              output << content_tag(:p, class: "adr") do
+              output << content_tag(:p, class: "adr content-block__body") do
                 %i[recipient street_address town_or_city state_or_county postal_code country].map { |field|
                   next if item[field].blank?
 
@@ -34,12 +34,6 @@ module ContentBlockTools
               postal_code: "postal-code",
               country: "country-name",
             }[field_name]
-          end
-
-        private
-
-          def show_title_in_field_names_context?
-            false
           end
         end
       end

--- a/lib/content_block_tools/presenters/block_presenters/contact/block_level_contact_item.rb
+++ b/lib/content_block_tools/presenters/block_presenters/contact/block_level_contact_item.rb
@@ -12,26 +12,20 @@ module ContentBlockTools
           end
 
           def wrapper(&block)
-            if @rendering_context == :field_names
-              content_tag(:div, class: "contact") do
-                concat title if show_title_in_field_names_context?
-                concat yield block
-              end
-            else
-              yield block
+            content_tag(:div) do
+              concat title
+              concat yield block
             end
           end
 
           def title
-            content_tag(:p,
-                        @content_block.title,
-                        class: "govuk-!-margin-bottom-3")
-          end
-
-        private
-
-          def show_title_in_field_names_context?
-            true
+            if @rendering_context == :field_names
+              content_tag(:p,
+                          @content_block.title,
+                          class: "content-block__title")
+            else
+              content_tag(:p, item[:title], class: "content-block__subtitle")
+            end
           end
         end
       end

--- a/lib/content_block_tools/presenters/block_presenters/contact/contact_link_presenter.rb
+++ b/lib/content_block_tools/presenters/block_presenters/contact/contact_link_presenter.rb
@@ -9,7 +9,7 @@ module ContentBlockTools
 
           def render
             wrapper do
-              content_tag(:div, class: "email-url-number") do
+              content_tag(:ul, class: "content-block__list") do
                 concat link
                 concat description if item[:description]
               end
@@ -17,10 +17,10 @@ module ContentBlockTools
           end
 
           def link
-            content_tag(:p) do
+            content_tag(:li) do
               content_tag(:a,
                           link_text,
-                          class: "url",
+                          class: "url content-block__link",
                           href: item[:url])
             end
           end
@@ -30,7 +30,9 @@ module ContentBlockTools
           end
 
           def description
-            render_govspeak(item[:description])
+            content_tag(:li) do
+              render_govspeak(item[:description])
+            end
           end
         end
       end

--- a/lib/content_block_tools/presenters/block_presenters/contact/email_address_presenter.rb
+++ b/lib/content_block_tools/presenters/block_presenters/contact/email_address_presenter.rb
@@ -9,18 +9,18 @@ module ContentBlockTools
 
           def render
             wrapper do
-              content_tag(:div, class: "email-url-number") do
+              content_tag(:ul, class: "content-block__list") do
                 concat email
-                concat render_govspeak(item[:description]) if item[:description].present?
+                concat description if item[:description].present?
               end
             end
           end
 
           def email
-            content_tag(:p) do
+            content_tag(:li) do
               concat content_tag(:a,
                                  link_text,
-                                 class: "email",
+                                 class: "email content-block__link",
                                  href: "mailto:#{item[:email_address]}#{query_params}")
             end
           end
@@ -36,6 +36,12 @@ module ContentBlockTools
 
           def link_text
             item[:label] || item[:email_address]
+          end
+
+          def description
+            content_tag(:li) do
+              render_govspeak(item[:description])
+            end
           end
         end
       end

--- a/lib/content_block_tools/presenters/block_presenters/contact/telephone_presenter.rb
+++ b/lib/content_block_tools/presenters/block_presenters/contact/telephone_presenter.rb
@@ -9,8 +9,8 @@ module ContentBlockTools
 
           def render
             wrapper do
-              content_tag(:div, class: "email-url-number") do
-                concat title_and_description
+              content_tag(:div) do
+                concat description if item[:description].present?
                 concat number_list
                 concat video_relay_service
                 concat bsl_details
@@ -20,29 +20,12 @@ module ContentBlockTools
             end
           end
 
-          def title_and_description
-            items = [
-              (item_title if item[:title].present?),
-              (description if item[:description].present?),
-            ].compact
-
-            if items.any?
-              content_tag(:div, class: "govuk-!-margin-bottom-3") do
-                concat items.join("").html_safe
-              end
-            end
-          end
-
-          def item_title
-            content_tag(:p, item[:title], { class: "govuk-!-margin-bottom-0" })
-          end
-
           def description
-            render_govspeak(item[:description], root_class: "govuk-!-margin-top-1 govuk-!-margin-bottom-0")
+            render_govspeak(item[:description], root_class: "content-block__body")
           end
 
           def number_list
-            content_tag(:ul) do
+            content_tag(:ul, class: "content-block__list") do
               item[:telephone_numbers].each do |number|
                 concat number_list_item(number)
               end
@@ -51,7 +34,7 @@ module ContentBlockTools
 
           def number_list_item(number)
             content_tag(:li) do
-              concat content_tag(:span, number[:label])
+              concat content_tag(:span, "#{number[:label]}: ")
               concat content_tag(:span, number[:telephone_number], { class: "tel" })
             end
           end
@@ -61,20 +44,20 @@ module ContentBlockTools
 
             if video_relay_service[:show]
               content = "#{video_relay_service[:prefix]} #{video_relay_service[:telephone_number]}"
-              render_govspeak(content, root_class: "govuk-!-margin-bottom-0")
+              render_govspeak(content, root_class: "content-block__body")
             end
           end
 
           def bsl_details
             bsl_guidance = item[:bsl_guidance] || {}
 
-            render_govspeak(bsl_guidance[:value], root_class: "govuk-!-margin-bottom-0") if bsl_guidance[:show]
+            render_govspeak(bsl_guidance[:value], root_class: "content-block__body") if bsl_guidance[:show]
           end
 
           def opening_hours
             opening_hours = item[:opening_hours] || {}
 
-            render_govspeak(opening_hours[:opening_hours], root_class: "govuk-!-margin-bottom-0") if opening_hours[:show_opening_hours]
+            render_govspeak(opening_hours[:opening_hours], root_class: "content-block__body") if opening_hours[:show_opening_hours]
           end
 
           def opening_hours_list_item(item)
@@ -88,7 +71,7 @@ module ContentBlockTools
               content_tag(:p) do
                 concat content_tag(:a,
                                    call_charges[:label],
-                                   class: "govuk-link",
+                                   class: "content-block__link",
                                    href: call_charges[:call_charges_info_url])
               end
             end

--- a/lib/content_block_tools/presenters/contact_presenter.rb
+++ b/lib/content_block_tools/presenters/contact_presenter.rb
@@ -22,16 +22,12 @@ module ContentBlockTools
     private
 
       def default_content
-        content_tag(:div, class: "contact") do
-          content_tag(:div, class: "content") do
-            content_tag(:div, class: "vcard contact-inner") do
-              concat content_tag(:p, content_block.title, class: "fn org")
-              concat render_govspeak(content_block.details[:description]) if content_block.details[:description]
-              embedded_objects.each do |object|
-                items = send(object)
-                concat(items.map { |item| presenter_for_object_type(object).new(item, content_block:).render }.join.html_safe)
-              end
-            end
+        content_tag(:div, class: "vcard") do
+          concat content_tag(:p, content_block.title, class: "fn org content-block__title")
+          concat render_govspeak(content_block.details[:description]) if content_block.details[:description]
+          embedded_objects.each do |object|
+            items = send(object)
+            concat(items.map { |item| presenter_for_object_type(object).new(item, content_block:).render }.join.html_safe)
           end
         end
       end

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "0.17.0"
+  VERSION = "1.0.0"
 end

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "content_block_tools",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "content_block_tools",
+      "license": "MIT",
+      "dependencies": {
+        "govuk-frontend": "^5.11.1"
+      }
+    },
+    "node_modules/govuk-frontend": {
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.11.1.tgz",
+      "integrity": "sha512-hJJFpaer4MZLvz/2F9RZ7xZ6FqlzpxL9aw6YWOGK3F1tn419xj2WcVXwOC8Bcj/dc/LanknbWJDGkb+IdkuhTQ==",
+      "engines": {
+        "node": ">= 4.2.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "content_block_tools",
+  "description": "A suite of tools for working with GOV.UK Content Blocks",
+  "license": "MIT",
+  "dependencies": {
+    "govuk-frontend": "^5.11.1"
+  }
+}

--- a/spec/content_block_tools/presenters/block_presenters/contact/address_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/block_presenters/contact/address_presenter_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::AddressP
 
     result = presenter.render
 
-    expect(result).to have_tag(:p) do
+    expect(result).to have_tag(:p, with: { class: "content-block__body" }) do
       with_tag(:span, text: "Department of something", with: { class: "organization-name" })
       with_tag(:span, text: "123 Fake Street", with: { class: "street-address" })
       with_tag(:span, text: "Springton", with: { class: "locality" })
@@ -48,7 +48,7 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::AddressP
     presenter = described_class.new(address, rendering_context: :field_names, content_block:)
 
     expect(presenter.render).to have_tag(:div, with: { class: "contact" }) do
-      with_tag(:p) do
+      with_tag(:p, with: { class: "content-block__body" }) do
         with_tag(:span, text: "Department of something", with: { class: "organization-name" })
         with_tag(:span, text: "123 Fake Street", with: { class: "street-address" })
         with_tag(:span, text: "Springton", with: { class: "locality" })
@@ -74,7 +74,7 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::AddressP
     it "should ignore the missing fields" do
       presenter = described_class.new(address, content_block:)
 
-      expect(presenter.render).to have_tag(:p) do
+      expect(presenter.render).to have_tag(:p, with: { class: "content-block__body" }) do
         with_tag(:span, text: "123 Fake Street", with: { class: "street-address" })
         with_tag(:span, text: "Springton", with: { class: "locality" })
         with_tag(:span, text: "TEST 123", with: { class: "postal-code" })

--- a/spec/content_block_tools/presenters/block_presenters/contact/address_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/block_presenters/contact/address_presenter_spec.rb
@@ -47,7 +47,8 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::AddressP
   it "should render successfully with field_names rendering context with the content block's title" do
     presenter = described_class.new(address, rendering_context: :field_names, content_block:)
 
-    expect(presenter.render).to have_tag(:div, with: { class: "contact" }) do
+    expect(presenter.render).to have_tag(:div) do
+      with_tag(:p, text: "My content block", with: { class: "content-block__title" })
       with_tag(:p, with: { class: "content-block__body" }) do
         with_tag(:span, text: "Department of something", with: { class: "organization-name" })
         with_tag(:span, text: "123 Fake Street", with: { class: "street-address" })

--- a/spec/content_block_tools/presenters/block_presenters/contact/contact_link_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/block_presenters/contact/contact_link_presenter_spec.rb
@@ -73,8 +73,8 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::ContactL
       presenter = described_class.new(contact_link, rendering_context: :field_names, content_block:)
       result = presenter.render
 
-      expect(result).to have_tag("div", with: { class: "contact" }) do
-        with_tag("p", text: content_block.title, with: { class: 'govuk-\!-margin-bottom-3' })
+      expect(result).to have_tag("div") do
+        with_tag("p", text: content_block.title, with: { class: "content-block__title" })
         with_tag("ul", with: { class: "content-block__list" })
       end
     end

--- a/spec/content_block_tools/presenters/block_presenters/contact/contact_link_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/block_presenters/contact/contact_link_presenter_spec.rb
@@ -20,8 +20,10 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::ContactL
   it "should render successfully" do
     presenter = described_class.new(contact_link, content_block:)
 
-    expect(presenter.render).to have_tag("p") do
-      with_tag("a", text: "Contact us", with: { href: "http://example.com", class: "url" })
+    expect(presenter.render).to have_tag("ul", with: { class: "content-block__list" }) do
+      with_tag("li") do
+        with_tag("a", text: "Contact us", with: { href: "http://example.com", class: "url content-block__link" })
+      end
     end
   end
 
@@ -36,8 +38,10 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::ContactL
     it "uses the url as the link text" do
       presenter = described_class.new(contact_link, content_block:)
 
-      expect(presenter.render).to have_tag("p") do
-        with_tag("a", text: "http://example.com", with: { href: "http://example.com", class: "url" })
+      expect(presenter.render).to have_tag("ul", with: { class: "content-block__list" }) do
+        with_tag("li") do
+          with_tag("a", text: "http://example.com", with: { href: "http://example.com", class: "url content-block__link" })
+        end
       end
     end
   end
@@ -58,8 +62,9 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::ContactL
       expect(presenter).to receive(:render_govspeak)
                              .with(contact_link[:description])
                              .and_call_original
-
-      expect(presenter.render).to have_tag("p", text: contact_link[:description])
+      expect(presenter.render).to have_tag("ul", with: { class: "content-block__list" }) do
+        with_tag("li", text: contact_link[:description])
+      end
     end
   end
 
@@ -70,7 +75,7 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::ContactL
 
       expect(result).to have_tag("div", with: { class: "contact" }) do
         with_tag("p", text: content_block.title, with: { class: 'govuk-\!-margin-bottom-3' })
-        with_tag("div", with: { class: "email-url-number" })
+        with_tag("ul", with: { class: "content-block__list" })
       end
     end
   end

--- a/spec/content_block_tools/presenters/block_presenters/contact/email_address_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/block_presenters/contact/email_address_presenter_spec.rb
@@ -101,8 +101,8 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::EmailAdd
       presenter = described_class.new(email_address, rendering_context: :field_names, content_block:)
       result = presenter.render
 
-      expect(result).to have_tag("div", with: { class: "contact" }) do
-        with_tag("p", text: content_block.title, with: { class: 'govuk-\!-margin-bottom-3' })
+      expect(result).to have_tag("div") do
+        with_tag("p", text: content_block.title, with: { class: "content-block__title" })
         with_tag("ul", with: { class: "content-block__list" })
       end
     end

--- a/spec/content_block_tools/presenters/block_presenters/contact/email_address_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/block_presenters/contact/email_address_presenter_spec.rb
@@ -20,8 +20,10 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::EmailAdd
   it "should render successfully" do
     presenter = described_class.new(email_address, content_block:)
 
-    expect(presenter.render).to have_tag("p") do
-      with_tag("a", text: "Email us", with: { href: "mailto:foo@example.com", class: "email" })
+    expect(presenter.render).to have_tag("ul", with: { class: "content-block__list" }) do
+      with_tag("li") do
+        with_tag("a", text: "Email us", with: { href: "mailto:foo@example.com", class: "email content-block__link" })
+      end
     end
   end
 
@@ -36,8 +38,10 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::EmailAdd
     it "uses the email address as the link text" do
       presenter = described_class.new(email_address, content_block:)
 
-      expect(presenter.render).to have_tag("p") do
-        with_tag("a", text: "foo@example.com", with: { href: "mailto:foo@example.com", class: "email" })
+      expect(presenter.render).to have_tag("ul", with: { class: "content-block__list" }) do
+        with_tag("li") do
+          with_tag("a", text: "foo@example.com", with: { href: "mailto:foo@example.com", class: "email content-block__link" })
+        end
       end
     end
   end
@@ -55,10 +59,10 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::EmailAdd
     it "should render successfully" do
       presenter = described_class.new(email_address, content_block:)
 
-      result = presenter.render
-
-      expect(result).to have_tag("p") do
-        with_tag("a", text: "foo@example.com", with: { href: "mailto:foo@example.com?subject=My email&body=Body text here", class: "email" })
+      expect(presenter.render).to have_tag("ul", with: { class: "content-block__list" }) do
+        with_tag("li") do
+          with_tag("a", text: "foo@example.com", with: { href: "mailto:foo@example.com?subject=My email&body=Body text here", class: "email content-block__link" })
+        end
       end
     end
   end
@@ -80,14 +84,14 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::EmailAdd
                              .with("Description text")
                              .and_call_original
 
-      result = presenter.render
-
-      expect(result).to have_tag("div", with: { class: "email-url-number" }) do
-        with_tag("p") do
-          with_tag("a", text: "Some email address", with: { href: "mailto:foo@example.com", class: "email" })
+      expect(presenter.render).to have_tag("ul", with: { class: "content-block__list" }) do
+        with_tag("li") do
+          with_tag("a", text: "Some email address", with: { href: "mailto:foo@example.com", class: "email content-block__link" })
         end
 
-        with_tag("p", text: "Description text")
+        with_tag("li") do
+          with_tag("p", text: "Description text")
+        end
       end
     end
   end
@@ -99,7 +103,7 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::EmailAdd
 
       expect(result).to have_tag("div", with: { class: "contact" }) do
         with_tag("p", text: content_block.title, with: { class: 'govuk-\!-margin-bottom-3' })
-        with_tag("div", with: { class: "email-url-number" })
+        with_tag("ul", with: { class: "content-block__list" })
       end
     end
   end

--- a/spec/content_block_tools/presenters/block_presenters/contact/telephone_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/block_presenters/contact/telephone_presenter_spec.rb
@@ -75,19 +75,15 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::Telephon
 
     expect(result).to_not have_tag("div", with: { class: "contact" })
 
-    expect(result).to have_tag("div", with: { class: "email-url-number" }) do
-      with_tag("div", with: { class: 'govuk-\!-margin-bottom-3' }) do
-        with_tag(:p, text: phone_number[:title], with: { class: 'govuk-\!-margin-bottom-0' })
-      end
-
-      with_tag("ul") do
+    expect(result).to have_tag("div") do
+      with_tag("ul", with: { class: "content-block__list" }) do
         with_tag("li") do
-          with_tag(:span, text: "Office")
+          with_tag(:span, text: "Office: ")
           with_tag(:span, text: "1234", with: { class: "tel" })
         end
 
         with_tag("li") do
-          with_tag(:span, text: "International")
+          with_tag(:span, text: "International: ")
           with_tag(:span, text: "5678", with: { class: "tel" })
         end
       end
@@ -106,15 +102,15 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::Telephon
 
       expect(result).to have_tag("ul", count: 1)
 
-      expect(result).to have_tag("div", with: { class: "email-url-number" }) do
-        with_tag("ul") do
+      expect(result).to have_tag("div") do
+        with_tag("ul", with: { class: "content-block__list" }) do
           with_tag("li") do
-            with_tag(:span, text: "Office")
+            with_tag(:span, text: "Office: ")
             with_tag(:span, text: "1234", with: { class: "tel" })
           end
 
           with_tag("li") do
-            with_tag(:span, text: "International")
+            with_tag(:span, text: "International: ")
             with_tag(:span, text: "5678", with: { class: "tel" })
           end
         end
@@ -131,15 +127,15 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::Telephon
 
       expect(result).to have_tag("ul", count: 1)
 
-      expect(result).to have_tag("div", with: { class: "email-url-number" }) do
-        with_tag("ul") do
+      expect(result).to have_tag("div") do
+        with_tag("ul", with: { class: "content-block__list" }) do
           with_tag("li") do
-            with_tag(:span, text: "Office")
+            with_tag(:span, text: "Office: ")
             with_tag(:span, text: "1234", with: { class: "tel" })
           end
 
           with_tag("li") do
-            with_tag(:span, text: "International")
+            with_tag(:span, text: "International: ")
             with_tag(:span, text: "5678", with: { class: "tel" })
           end
         end
@@ -154,7 +150,7 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::Telephon
       presenter = described_class.new(phone_number, content_block:)
 
       expect(presenter).to receive(:render_govspeak)
-                             .with(opening_hours[:opening_hours], root_class: "govuk-!-margin-bottom-0")
+                             .with(opening_hours[:opening_hours], root_class: "content-block__body")
                              .and_call_original
 
       result = presenter.render
@@ -184,18 +180,15 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::Telephon
       presenter = described_class.new(phone_number, content_block:)
 
       expect(presenter).to receive(:render_govspeak)
-                             .with(description, root_class: "govuk-!-margin-top-1 govuk-!-margin-bottom-0")
+                             .with(description, root_class: "content-block__body")
                              .and_call_original
 
       result = presenter.render
 
       expect(result).to_not have_tag("div", with: { class: "contact" })
 
-      expect(result).to have_tag("div", with: { class: "email-url-number" }) do
-        with_tag("div", with: { class: 'govuk-\!-margin-bottom-3' }) do
-          with_tag(:p, text: phone_number[:title], with: { class: 'govuk-\!-margin-bottom-0' })
-          with_tag(:p, text: phone_number[:description], with: { class: 'govuk-\!-margin-top-1 govuk-\!-margin-bottom-0' })
-        end
+      expect(result).to have_tag("div") do
+        with_tag(:p, text: phone_number[:description], with: { class: "content-block__body" })
       end
     end
   end
@@ -207,12 +200,12 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::Telephon
       presenter = described_class.new(phone_number, content_block:)
 
       expect(presenter).to receive(:render_govspeak)
-                             .with(bsl_guidance[:value], root_class: "govuk-!-margin-bottom-0")
+                             .with(bsl_guidance[:value], root_class: "content-block__body")
                              .and_call_original
 
       result = presenter.render
 
-      expect(result).to have_tag(:p, text: bsl_guidance[:value], with: { class: 'govuk-\!-margin-bottom-0' })
+      expect(result).to have_tag(:p, text: bsl_guidance[:value], with: { class: "content-block__body" })
     end
   end
 
@@ -223,12 +216,12 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::Telephon
       presenter = described_class.new(phone_number, content_block:)
 
       expect(presenter).to receive(:render_govspeak)
-                             .with("#{video_relay_service[:prefix]} #{video_relay_service[:telephone_number]}", root_class: "govuk-!-margin-bottom-0")
+                             .with("#{video_relay_service[:prefix]} #{video_relay_service[:telephone_number]}", root_class: "content-block__body")
                              .and_call_original
 
       result = presenter.render
 
-      expect(result).to have_tag(:p, text: "#{video_relay_service[:prefix]} #{video_relay_service[:telephone_number]}", with: { class: 'govuk-\!-margin-bottom-0' })
+      expect(result).to have_tag(:p, text: "#{video_relay_service[:prefix]} #{video_relay_service[:telephone_number]}", with: { class: "content-block__body" })
     end
   end
 
@@ -239,7 +232,7 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::Telephon
 
       expect(result).to have_tag("div", with: { class: "contact" }) do
         with_tag("p", text: content_block.title, with: { class: 'govuk-\!-margin-bottom-3' })
-        with_tag("div", with: { class: "email-url-number" })
+        with_tag("ul", with: { class: "content-block__list" })
       end
     end
   end

--- a/spec/content_block_tools/presenters/block_presenters/contact/telephone_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/block_presenters/contact/telephone_presenter_spec.rb
@@ -230,8 +230,8 @@ RSpec.describe ContentBlockTools::Presenters::BlockPresenters::Contact::Telephon
       presenter = described_class.new(phone_number, rendering_context: :field_names, content_block:)
       result = presenter.render
 
-      expect(result).to have_tag("div", with: { class: "contact" }) do
-        with_tag("p", text: content_block.title, with: { class: 'govuk-\!-margin-bottom-3' })
+      expect(result).to have_tag("div") do
+        with_tag("p", text: content_block.title, with: { class: "content-block__title" })
         with_tag("ul", with: { class: "content-block__list" })
       end
     end

--- a/spec/content_block_tools/presenters/contact_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/contact_presenter_spec.rb
@@ -172,9 +172,9 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
           with_tag("div", with: { class: "content" }) do
             with_tag("div", with: { class: "vcard contact-inner" }) do
               with_tag("p", text: "My Contact")
-              with_tag("ul") do
+              with_tag("ul", with: { class: "content-block__list" }) do
                 with_tag("li") do
-                  with_tag("span", text: "Telephone")
+                  with_tag("span", text: "Telephone: ")
                   with_tag("span", text: "0891 50 50 50", with: { class: "tel" })
                 end
               end
@@ -201,12 +201,10 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
 
       expect(presenter.render).to have_tag("div", with: expected_wrapper_attributes.merge({ "data-embed-code" => embed_code, "data-document-type" => "contact" })) do
         with_tag("div", with: { class: "contact" }) do
-          with_tag("div", with: { class: "email-url-number" }) do
-            with_tag("ul") do
-              with_tag("li") do
-                with_tag("span", text: "Telephone")
-                with_tag("span", text: "0891 50 50 50", with: { class: "tel" })
-              end
+          with_tag("ul", with: { class: "content-block__list" }) do
+            with_tag("li") do
+              with_tag("span", text: "Telephone: ")
+              with_tag("span", text: "0891 50 50 50", with: { class: "tel" })
             end
           end
         end

--- a/spec/content_block_tools/presenters/contact_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/contact_presenter_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
         with_tag("div", with: { class: "contact" }) do
           with_tag("div", with: { class: "content" }) do
             with_tag("div", with: { class: "vcard contact-inner" }) do
-              with_tag("p") do
+              with_tag("p", with: { class: "content-block__body" }) do
                 with_text "Department of something,123 Fake Street,Springton,Missouri,TEST 123,USA"
                 with_tag "br", count: 5
               end

--- a/spec/content_block_tools/presenters/contact_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/contact_presenter_spec.rb
@@ -31,12 +31,8 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
       presenter = described_class.new(content_block)
 
       expect(presenter.render).to have_tag("div", with: expected_wrapper_attributes) do
-        with_tag("div", with: { class: "contact" }) do
-          with_tag("div", with: { class: "content" }) do
-            with_tag("div", with: { class: "vcard contact-inner" }) do
-              with_tag("p", text: "My Contact", with: { class: "fn org" })
-            end
-          end
+        with_tag("div", with: { class: "vcard" }) do
+          with_tag("p", text: "My Contact", with: { class: "fn org" })
         end
       end
     end
@@ -65,15 +61,12 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
       presenter = described_class.new(content_block)
 
       expect(presenter.render).to have_tag("div", with: expected_wrapper_attributes) do
-        with_tag("div", with: { class: "contact" }) do
-          with_tag("div", with: { class: "content" }) do
-            with_tag("div", with: { class: "vcard contact-inner" }) do
-              with_tag("p", text: "My Contact")
-              with_tag("ul", with: { class: "content-block__list" }) do
-                with_tag("li") do
-                  with_tag("a", text: "foo@example.com", with: { href: "mailto:foo@example.com" })
-                end
-              end
+        with_tag("div", with: { class: "vcard" }) do
+          with_tag("p", text: "My Contact")
+          with_tag("p", text: "Some email address", with: { class: "content-block__subtitle" })
+          with_tag("ul", with: { class: "content-block__list" }) do
+            with_tag("li") do
+              with_tag("a", text: "foo@example.com", with: { href: "mailto:foo@example.com" })
             end
           end
         end
@@ -94,7 +87,7 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
       presenter = described_class.new(content_block)
 
       expect(presenter.render).to have_tag("div", with: expected_wrapper_attributes.merge({ "data-embed-code" => embed_code })) do
-        with_tag("div", with: { class: "contact" }) do
+        with_tag("div") do
           with_tag("ul", with: { class: "content-block__list" }) do
             with_tag("li") do
               with_tag("a", text: "foo@example.com", with: { href: "mailto:foo@example.com" })
@@ -168,20 +161,17 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
       presenter = described_class.new(content_block)
 
       expect(presenter.render).to have_tag("div", with: expected_wrapper_attributes) do
-        with_tag("div", with: { class: "contact" }) do
-          with_tag("div", with: { class: "content" }) do
-            with_tag("div", with: { class: "vcard contact-inner" }) do
-              with_tag("p", text: "My Contact")
-              with_tag("ul", with: { class: "content-block__list" }) do
-                with_tag("li") do
-                  with_tag("span", text: "Telephone: ")
-                  with_tag("span", text: "0891 50 50 50", with: { class: "tel" })
-                end
-              end
-
-              with_tag("p", text: "Monday to Friday, 9am to 5pm")
+        with_tag("div", with: { class: "vcard" }) do
+          with_tag("p", text: "My Contact")
+          with_tag("p", text: "Some phone number", with: { class: "content-block__subtitle" })
+          with_tag("ul", with: { class: "content-block__list" }) do
+            with_tag("li") do
+              with_tag("span", text: "Telephone: ")
+              with_tag("span", text: "0891 50 50 50", with: { class: "tel" })
             end
           end
+
+          with_tag("p", text: "Monday to Friday, 9am to 5pm")
         end
       end
     end
@@ -200,7 +190,7 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
       presenter = described_class.new(content_block)
 
       expect(presenter.render).to have_tag("div", with: expected_wrapper_attributes.merge({ "data-embed-code" => embed_code, "data-document-type" => "contact" })) do
-        with_tag("div", with: { class: "contact" }) do
+        with_tag("div") do
           with_tag("ul", with: { class: "content-block__list" }) do
             with_tag("li") do
               with_tag("span", text: "Telephone: ")
@@ -265,14 +255,11 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
       presenter = described_class.new(content_block)
 
       expect(presenter.render).to have_tag("div", with: expected_wrapper_attributes) do
-        with_tag("div", with: { class: "contact" }) do
-          with_tag("div", with: { class: "content" }) do
-            with_tag("div", with: { class: "vcard contact-inner" }) do
-              with_tag("p", with: { class: "content-block__body" }) do
-                with_text "Department of something,123 Fake Street,Springton,Missouri,TEST 123,USA"
-                with_tag "br", count: 5
-              end
-            end
+        with_tag("div", with: { class: "vcard" }) do
+          with_tag("p", text: "Address", with: { class: "content-block__subtitle" })
+          with_tag("p", with: { class: "content-block__body" }) do
+            with_text "Department of something,123 Fake Street,Springton,Missouri,TEST 123,USA"
+            with_tag "br", count: 5
           end
         end
       end
@@ -292,7 +279,7 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
       presenter = described_class.new(content_block)
 
       expect(presenter.render).to have_tag("div", with: expected_wrapper_attributes.merge({ "data-embed-code" => embed_code, "data-document-type" => "contact" })) do
-        with_tag(:div, with: { class: "contact" }) do
+        with_tag(:div) do
           with_text "Department of something,123 Fake Street,Springton,Missouri,TEST 123,USA"
           with_tag "br", count: 5
         end
@@ -323,14 +310,11 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
       presenter = described_class.new(content_block)
 
       expect(presenter.render).to have_tag("div", with: expected_wrapper_attributes) do
-        with_tag("div", with: { class: "contact" }) do
-          with_tag("div", with: { class: "content" }) do
-            with_tag("div", with: { class: "vcard contact-inner" }) do
-              with_tag("p", text: "My Contact")
-              with_tag("ul") do
-                with_tag("a", text: "http://example.com", with: { href: "http://example.com" })
-              end
-            end
+        with_tag("div", with: { class: "vcard" }) do
+          with_tag("p", text: "Some contact form", with: { class: "content-block__subtitle" })
+          with_tag("p", text: "My Contact")
+          with_tag("ul") do
+            with_tag("a", text: "http://example.com", with: { href: "http://example.com" })
           end
         end
       end
@@ -350,7 +334,7 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
       presenter = described_class.new(content_block)
 
       expect(presenter.render).to have_tag("div", with: expected_wrapper_attributes.merge({ "data-embed-code" => embed_code, "data-document-type" => "contact" })) do
-        with_tag("div", with: { class: "contact" }) do
+        with_tag("div") do
           with_tag("ul", with: { class: "content-block__list" }) do
             with_tag("li") do
               with_tag("a", text: "http://example.com", with: { href: "http://example.com" })
@@ -372,7 +356,7 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
                              .and_call_original
 
       expect(presenter.render).to have_tag("div", with: expected_wrapper_attributes) do
-        with_tag("div", with: { class: "contact" }) do
+        with_tag("div") do
           with_tag("p", text: description)
         end
       end

--- a/spec/content_block_tools/presenters/contact_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/contact_presenter_spec.rb
@@ -69,8 +69,10 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
           with_tag("div", with: { class: "content" }) do
             with_tag("div", with: { class: "vcard contact-inner" }) do
               with_tag("p", text: "My Contact")
-              with_tag("p") do
-                with_tag("a", text: "foo@example.com", with: { href: "mailto:foo@example.com" })
+              with_tag("ul", with: { class: "content-block__list" }) do
+                with_tag("li") do
+                  with_tag("a", text: "foo@example.com", with: { href: "mailto:foo@example.com" })
+                end
               end
             end
           end
@@ -93,8 +95,8 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
 
       expect(presenter.render).to have_tag("div", with: expected_wrapper_attributes.merge({ "data-embed-code" => embed_code })) do
         with_tag("div", with: { class: "contact" }) do
-          with_tag("div", with: { class: "email-url-number" }) do
-            with_tag("p") do
+          with_tag("ul", with: { class: "content-block__list" }) do
+            with_tag("li") do
               with_tag("a", text: "foo@example.com", with: { href: "mailto:foo@example.com" })
             end
           end

--- a/spec/content_block_tools/presenters/contact_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/contact_presenter_spec.rb
@@ -327,7 +327,7 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
           with_tag("div", with: { class: "content" }) do
             with_tag("div", with: { class: "vcard contact-inner" }) do
               with_tag("p", text: "My Contact")
-              with_tag("p") do
+              with_tag("ul") do
                 with_tag("a", text: "http://example.com", with: { href: "http://example.com" })
               end
             end
@@ -351,8 +351,8 @@ RSpec.describe ContentBlockTools::Presenters::ContactPresenter do
 
       expect(presenter.render).to have_tag("div", with: expected_wrapper_attributes.merge({ "data-embed-code" => embed_code, "data-document-type" => "contact" })) do
         with_tag("div", with: { class: "contact" }) do
-          with_tag("div", with: { class: "email-url-number" }) do
-            with_tag("p") do
+          with_tag("ul", with: { class: "content-block__list" }) do
+            with_tag("li") do
               with_tag("a", text: "http://example.com", with: { href: "http://example.com" })
             end
           end


### PR DESCRIPTION
This updates the contact block markup to map more closely to the pattern in the design system - see https://design-system.service.gov.uk/patterns/contact-a-department-or-service-team/

As well as this, we've had to ship styles, as wrapping content in the `govspeak` class overrides some styling like paragraphs and lists. Once this is released, we'll have to include the gem in the frontend apps too, to ensure the styles are used correctly.

## Screenshots

### Before

#### Default block

<img width="556" height="685" alt="image" src="https://github.com/user-attachments/assets/a5e0325b-a7fc-4774-bd4d-e5e76e69e247" />

#### Email block

<img width="340" height="160" alt="image" src="https://github.com/user-attachments/assets/f41cf29b-e46b-4a1d-9e35-f9cee00f3237" />

#### Telephone block

<img width="340" height="375" alt="image" src="https://github.com/user-attachments/assets/e837b665-4b54-4d0a-b1d9-60c358279c8a" />

#### Address block

<img width="339" height="117" alt="image" src="https://github.com/user-attachments/assets/55007fd8-e583-4931-ba8b-4b7a2d8ff824" />

#### Contact link block

<img width="340" height="90" alt="image" src="https://github.com/user-attachments/assets/8028aeed-bca3-4144-a156-c24d1da41650" />

### After

#### Default block

<img width="1138" height="864" alt="image" src="https://github.com/user-attachments/assets/f6128c33-d932-40a3-a3c8-ed6bdf1e80a7" />

#### Email block

<img width="340" height="105" alt="image" src="https://github.com/user-attachments/assets/e9405e7e-6fb8-43dd-9e42-89f1fc569a6e" />

#### Telephone block

<img width="340" height="320" alt="image" src="https://github.com/user-attachments/assets/4f0ddc99-f248-4fd0-bdd5-3aaef0eb7663" />

#### Address block

<img width="340" height="125" alt="image" src="https://github.com/user-attachments/assets/8beb1fdf-fd93-4f9d-ab7a-9b0cf1ead6aa" />

#### Contact link block

<img width="340" height="105" alt="image" src="https://github.com/user-attachments/assets/4ce88757-11bf-488d-bb99-67586aa31186" />

