### PR TITLE
Fix publish step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       - env:
           GEM_HOST_API_KEY: ${{ secrets.ALPHAGOV_RUBYGEMS_API_KEY }}
         run: |
-          VERSION=$(ruby -e "puts eval(File.read('content_block_tools.gemspec')).version")
+          VERSION=$(ruby -r rubygems -e "puts Gem::Specification::load('content_block_tools.gemspec').version")
           GEM_VERSION=$(gem list --exact --remote content_block_tools)
           
           if [ "${GEM_VERSION}" != "content_block_tools (${VERSION})" ]; then


### PR DESCRIPTION
The code we were using threw an error. This part is taken from the [publish-rubygem](https://github.com/alphagov/govuk-infrastructure/blob/main/.github/workflows/publish-rubygem.yml) workflow and is confirmed to work.