### PR TITLE
Only add to assets path when present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 1.0.2
+
+- Only add paths to assets if `assets` is defined ([79](https://github.com/alphagov/govuk_content_block_tools/pull/79))
+
 ## 1.0.1
 
 - Include `node_modules` directory in published gem ([78](https://github.com/alphagov/govuk_content_block_tools/pull/78))

--- a/lib/content_block_tools/engine.rb
+++ b/lib/content_block_tools/engine.rb
@@ -3,10 +3,12 @@ module ContentBlockTools
     isolate_namespace ContentBlockTools
 
     initializer "content_block_tools.assets" do
-      Rails.application.config.assets.paths += %w[
-        app/assets/stylesheets
-        node_modules/govuk-frontend/dist/govuk/core
-      ]
+      if defined? Rails.application.config.assets
+        Rails.application.config.assets.paths += %w[
+          app/assets/stylesheets
+          node_modules/govuk-frontend/dist/govuk/core
+        ]
+      end
     end
 
     initializer "content_block_tools.initialize_logger" do

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
When adding the gem to Publishing API we get an error, as Sprockets is not present in this app. Adding this check will ensure the gem can be included and the app will start cleanly.
