### PR TITLE
Import govuk links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 1.0.3
+
+- Import govuk-links ([80](https://github.com/alphagov/govuk_content_block_tools/pull/80))
+
 ## 1.0.2
 
 - Only add paths to assets if `assets` is defined ([79](https://github.com/alphagov/govuk_content_block_tools/pull/79))

--- a/app/assets/stylesheets/content_block_tools.scss
+++ b/app/assets/stylesheets/content_block_tools.scss
@@ -1,3 +1,4 @@
+@import "govuk/core/links";
 @import "govuk/core/lists";
 @import "govuk/core/typography";
 

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end


### PR DESCRIPTION
This wasn’t imported, so applications where govuk-frontend wasn’t fully included choked.