### PR TITLE
(CM-515) Tweak styling content blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 1.3.1
+
+* Tweak rendering of Address and Telephone blocks ([100](https://github.com/alphagov/govuk_content_block_tools/pull/100))
+
 ## 1.3.0
 
 * Allow composed blocks to be sorted ([95](https://github.com/alphagov/govuk_content_block_tools/pull/95))

--- a/app/components/content_block_tools/contacts/address_component.html.erb
+++ b/app/components/content_block_tools/contacts/address_component.html.erb
@@ -1,5 +1,5 @@
 <p class="adr">
-  <%= lines.map { |field, value| address_line(field, value) }.join(",<br />").html_safe %>
+  <%= lines.map { |field, value| address_line(field, value) }.join("<br />").html_safe %>
 </p>
 
 <%= render_govspeak(item[:description]) if item[:description].present? %>

--- a/app/components/content_block_tools/contacts/telephone_component.html.erb
+++ b/app/components/content_block_tools/contacts/telephone_component.html.erb
@@ -2,7 +2,7 @@
   <%= render_govspeak(item[:description]) %>
 <% end %>
 
-<ul class="content-block__list">
+<ul class="content-block__list govuk-!-margin-bottom-0">
   <% item[:telephone_numbers].each do |number| %>
     <li>
       <span><%= number[:label] %>: </span>

--- a/app/components/content_block_tools/contacts/telephone_component.html.erb
+++ b/app/components/content_block_tools/contacts/telephone_component.html.erb
@@ -4,7 +4,7 @@
 
 <ul class="content-block__list govuk-!-margin-bottom-0">
   <% item[:telephone_numbers].each do |number| %>
-    <li>
+    <li class="govuk-!-margin-bottom-1">
       <span><%= number[:label] %>: </span>
       <span class="tel"><%= number[:telephone_number] %></span>
     </li>

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "1.3.0"
+  VERSION = "1.3.1"
 end


### PR DESCRIPTION
# Description

[Jira Ticket](https://gov-uk.atlassian.net/browse/CM-515)

Tweaks two visual issues in some of the content blocks:
1. Removes the trailing `,` (comma) on each line of an address.
2. Removes the gap between the numbers and the opening hours in a telephone number contact block.

## Before:
<img width="1192" height="1425" alt="before" src="https://github.com/user-attachments/assets/7c480fe3-ee58-473d-a858-d110db466883" />

## After:
<img width="1192" height="1425" alt="after" src="https://github.com/user-attachments/assets/e88761a6-9996-4cf4-9d7b-1762dd8c385c" />
