### PR TITLE
Remove pessimistic version constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 1.10.3
+
+* Remove pessimistic version constraint on `gds-api-adapters`
+
 # 1.10.2
 
 * Handle `TimePeriod` missing its `date_range` gracefully

--- a/content_block_tools.gemspec
+++ b/content_block_tools.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov"
 
   spec.add_dependency "actionview", ">= 6", "< 8.1.3"
-  spec.add_dependency "gds-api-adapters", ">= 101.0", "< 103.1"
+  spec.add_dependency "gds-api-adapters", ">= 101.0"
   spec.add_dependency "govspeak", ">= 10.6.3"
   spec.add_dependency "rails", ">= 6", "< 8.1.3"
   spec.add_dependency "view_component", "~> 4"

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "1.10.2"
+  VERSION = "1.10.3"
 end


### PR DESCRIPTION
As `gds-api-adapters` is updated on a fairly regular basis, the newest version often drifts. There’s no real need to specify a maximum version, as we don’t expect breaking changes (these will be picked up by tests anyway), so let’s remove the maximum costraint.