### PR TITLE
Experiment: present alternate formats of a block

### DIFF
--- a/app/components/content_block_tools/time_period_component.html.erb
+++ b/app/components/content_block_tools/time_period_component.html.erb
@@ -1,8 +1,0 @@
-<% if start_date.present? && end_date.present?  %>
-  <p class="govuk-body">
-    <%= start_date %>
-    to
-    <%= end_date %>
-  </p>
-<% end %>
-

--- a/app/components/content_block_tools/time_period_component.rb
+++ b/app/components/content_block_tools/time_period_component.rb
@@ -1,29 +1,123 @@
 module ContentBlockTools
   class TimePeriodComponent < ContentBlockTools::BaseComponent
+    SUPPORTED_FORMATS = %w[
+      default
+      long_form
+      start_day_and_month
+      start_month_as_word
+      years
+      years_short
+    ].freeze
+
     def initialize(content_block:, _block_type: nil, _block_name: nil)
       @content_block = content_block
+      validate_format!
     end
 
-    def start_date
-      presented_date(
-        content_block.details.dig(:date_range, :start, :date),
-      )
-    end
-
-    def end_date
-      presented_date(
-        content_block.details.dig(:date_range, :end, :date),
-      )
+    def render
+      case format
+      when "default"
+        render_default
+      when "long_form"
+        render_long_form
+      when "start_day_and_month"
+        render_start_day_and_month
+      when "start_month_as_word"
+        render_start_month_as_word
+      when "years"
+        render_years
+      when "years_short"
+        render_years_short
+      end
     end
 
   private
 
     attr_reader :content_block
 
-    def presented_date(date)
-      Presenters::FieldPresenters::TimePeriod::DatePresenter.new(
-        date,
-      ).render
+    delegate :format, to: :content_block
+
+    def validate_format!
+      return if SUPPORTED_FORMATS.include?(format)
+
+      raise InvalidFormatError, "Unknown format '#{format}' for time_period"
+    end
+
+    def render_default
+      return "" unless start_date && end_date
+
+      content_tag(:p, class: "govuk-body") do
+        "#{format_date(start_date, :full)} to #{format_date(end_date, :full)}"
+      end
+    end
+
+    def render_long_form
+      return "" unless start_date && end_date
+
+      content_tag(:p, class: "govuk-body") do
+        "#{format_date(start_date, :month_year)} to " \
+          "#{format_date(end_date, :month_year)}"
+      end
+    end
+
+    def render_start_day_and_month
+      return "" unless start_date
+
+      content_tag(:p, class: "govuk-body") do
+        format_date(start_date, :day_month)
+      end
+    end
+
+    def render_start_month_as_word
+      return "" unless start_date
+
+      content_tag(:p, class: "govuk-body") do
+        format_date(start_date, :month_only)
+      end
+    end
+
+    def render_years
+      return "" unless start_date && end_date
+
+      content_tag(:p, class: "govuk-body") do
+        "#{start_date.year}-#{end_date.year}"
+      end
+    end
+
+    def render_years_short
+      return "" unless start_date && end_date
+
+      content_tag(:p, class: "govuk-body") do
+        "#{start_date.year}-#{end_date.strftime('%y')}"
+      end
+    end
+
+    def start_date
+      @start_date ||= parse_date(:start)
+    end
+
+    def end_date
+      @end_date ||= parse_date(:end)
+    end
+
+    def parse_date(key)
+      date_string = content_block.details.dig(:date_range, key, :date)
+      return unless date_string
+
+      Date.parse(date_string)
+    end
+
+    def format_date(date, style)
+      case style
+      when :full
+        date.strftime("%e %B %Y").strip
+      when :month_year
+        date.strftime("%B %Y")
+      when :day_month
+        date.strftime("%e %B").strip
+      when :month_only
+        date.strftime("%B")
+      end
     end
   end
 end

--- a/content_block_tools.gemspec
+++ b/content_block_tools.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]
 
+  spec.add_development_dependency "cucumber", "~> 9.0"
   spec.add_development_dependency "rake", "13.3.1"
   spec.add_development_dependency "rspec-html-matchers", "0.10.0"
   spec.add_development_dependency "rspec-rails"

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+default: --publish-quiet

--- a/features/step_definitions/time_period_steps.rb
+++ b/features/step_definitions/time_period_steps.rb
@@ -12,7 +12,29 @@ Given("a TimePeriod content block with the following details:") do |table|
 end
 
 When("asked to render a block with {string}") do |embed_code|
-  # Stub the Content Store API response
+  stub_content_store_api
+
+  # Use the main entrypoint - exercises full code pathway
+  content_block = ContentBlockTools::ContentBlock.from_embed_code(embed_code)
+
+  begin
+    component = ContentBlockTools::TimePeriodComponent.new(content_block: content_block)
+    @rendered_output = component.render
+  rescue ContentBlockTools::InvalidFormatError => e
+    @raised_error = e
+  end
+end
+
+Then("the rendered output should contain {string}") do |expected_text|
+  expect(@rendered_output).to have_tag("p", seen: expected_text)
+end
+
+Then("an InvalidFormatError should be raised with message {string}") do |message|
+  expect(@raised_error).to be_a(ContentBlockTools::InvalidFormatError)
+  expect(@raised_error.message).to eq(message)
+end
+
+def stub_content_store_api
   api_response = {
     "content_id" => @content_id,
     "title" => "Tax year",
@@ -23,14 +45,4 @@ When("asked to render a block with {string}") do |embed_code|
   content_store = double(GdsApi::ContentStore)
   allow(GdsApi).to receive(:content_store).and_return(content_store)
   allow(content_store).to receive(:content_item).and_return(api_response)
-
-  # Use the main entrypoint - exercises full code pathway
-  content_block = ContentBlockTools::ContentBlock.from_embed_code(embed_code)
-
-  component = ContentBlockTools::TimePeriodComponent.new(content_block: content_block)
-  @rendered_output = component.render
-end
-
-Then("the rendered output should contain {string}") do |expected_text|
-  expect(@rendered_output).to have_tag("p", seen: expected_text)
 end

--- a/features/step_definitions/time_period_steps.rb
+++ b/features/step_definitions/time_period_steps.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+Given("a TimePeriod content block with the following details:") do |table|
+  data = table.rows_hash
+  @content_id = SecureRandom.uuid
+  @details = {
+    "date_range" => {
+      "start" => { "date" => data["start_date"], "time" => "00:00" },
+      "end" => { "date" => data["end_date"], "time" => "23:59" },
+    },
+  }
+end
+
+When("asked to render a block with {string}") do |embed_code|
+  # Stub the Content Store API response
+  api_response = {
+    "content_id" => @content_id,
+    "title" => "Tax year",
+    "document_type" => "content_block_time_period",
+    "details" => @details,
+  }
+
+  content_store = double(GdsApi::ContentStore)
+  allow(GdsApi).to receive(:content_store).and_return(content_store)
+  allow(content_store).to receive(:content_item).and_return(api_response)
+
+  # Use the main entrypoint - exercises full code pathway
+  content_block = ContentBlockTools::ContentBlock.from_embed_code(embed_code)
+
+  component = ContentBlockTools::TimePeriodComponent.new(content_block: content_block)
+  @rendered_output = component.render
+end
+
+Then("the rendered output should contain {string}") do |expected_text|
+  expect(@rendered_output).to have_tag("p", seen: expected_text)
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "securerandom"
+require "rspec/expectations"
+require "rspec/mocks"
+require "rspec-html-matchers"
+
+# Load the dummy Rails app (same as RSpec uses)
+require File.expand_path("../../spec/dummy/config/environment", __dir__)
+
+World(RSpec::Matchers)
+World(RSpec::Mocks::ExampleMethods)
+World(RSpecHtmlMatchers)
+
+# Enable RSpec mocks in Cucumber
+Around do |_scenario, block|
+  RSpec::Mocks.setup
+  block.call
+  RSpec::Mocks.verify
+ensure
+  RSpec::Mocks.teardown
+end

--- a/features/time_period_rendering.feature
+++ b/features/time_period_rendering.feature
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Feature: Render TimePeriod content block
+  So that I present date ranges on GOV.UK pages expected way
+  As a publishing platform
+  I want time periods blocks to be rendered in the specified format
+
+  Background:
+    Given a TimePeriod content block with the following details:
+      | start_date | 2025-04-06 |
+      | end_date   | 2026-04-05 |
+
+  Scenario: Render with default format when no format specified
+    When asked to render a block with "{{embed:content_block_time_period:tax-year}}"
+    Then the rendered output should contain "6 April 2025 to 5 April 2026"

--- a/features/time_period_rendering.feature
+++ b/features/time_period_rendering.feature
@@ -13,3 +13,31 @@ Feature: Render TimePeriod content block
   Scenario: Render with default format when no format specified
     When asked to render a block with "{{embed:content_block_time_period:tax-year}}"
     Then the rendered output should contain "6 April 2025 to 5 April 2026"
+
+  Scenario: Render with explicit default format
+    When asked to render a block with "{{embed:content_block_time_period:tax-year|default}}"
+    Then the rendered output should contain "6 April 2025 to 5 April 2026"
+
+  Scenario: Render with long_form format
+    When asked to render a block with "{{embed:content_block_time_period:tax-year|long_form}}"
+    Then the rendered output should contain "April 2025 to April 2026"
+
+  Scenario: Render with start_day_and_month format
+    When asked to render a block with "{{embed:content_block_time_period:tax-year|start_day_and_month}}"
+    Then the rendered output should contain "6 April"
+
+  Scenario: Render with start_month_as_word format
+    When asked to render a block with "{{embed:content_block_time_period:tax-year|start_month_as_word}}"
+    Then the rendered output should contain "April"
+
+  Scenario: Render with years format
+    When asked to render a block with "{{embed:content_block_time_period:tax-year|years}}"
+    Then the rendered output should contain "2025-2026"
+
+  Scenario: Render with years_short format
+    When asked to render a block with "{{embed:content_block_time_period:tax-year|years_short}}"
+    Then the rendered output should contain "2025-26"
+
+  Scenario: Raise error for invalid format
+    When asked to render a block with "{{embed:content_block_time_period:tax-year|unknown_format}}"
+    Then an InvalidFormatError should be raised with message "Unknown format 'unknown_format' for time_period"

--- a/lib/content_block_tools.rb
+++ b/lib/content_block_tools.rb
@@ -27,6 +27,7 @@ require "content_block_tools/version"
 module ContentBlockTools
   class Error < StandardError; end
   class InvalidEmbedCodeError < StandardError; end
+  class InvalidFormatError < StandardError; end
 
   module Presenters; end
 

--- a/lib/content_block_tools.rb
+++ b/lib/content_block_tools.rb
@@ -16,6 +16,7 @@ require "content_block_tools/presenters/field_presenters/time_period/time_presen
 
 require "content_block_tools/content_block"
 require "content_block_tools/content_block_reference"
+require "content_block_tools/format"
 
 require "content_block_tools/engine"
 

--- a/lib/content_block_tools.rb
+++ b/lib/content_block_tools.rb
@@ -16,6 +16,7 @@ require "content_block_tools/presenters/field_presenters/time_period/time_presen
 
 require "content_block_tools/content_block"
 require "content_block_tools/content_block_reference"
+require "content_block_tools/embed_code"
 require "content_block_tools/format"
 
 require "content_block_tools/engine"

--- a/lib/content_block_tools.rb
+++ b/lib/content_block_tools.rb
@@ -18,6 +18,7 @@ require "content_block_tools/content_block"
 require "content_block_tools/content_block_reference"
 require "content_block_tools/embed_code"
 require "content_block_tools/format"
+require "content_block_tools/renderer"
 
 require "content_block_tools/engine"
 

--- a/lib/content_block_tools/content_block.rb
+++ b/lib/content_block_tools/content_block.rb
@@ -44,7 +44,7 @@ module ContentBlockTools
 
     CONTENT_BLOCK_PREFIX = "content_block_".freeze
 
-    attr_reader :content_id, :title, :embed_code
+    attr_reader :content_id, :title, :embed_code, :format
 
     # Creates a ContentBlock instance from an embed code string by fetching
     # the content item data from the Content Store API.
@@ -75,15 +75,17 @@ module ContentBlockTools
         document_type: api_response["document_type"],
         details: api_response["details"],
         embed_code:,
+        format: Format.from_embed_code(embed_code),
       )
     end
 
-    def initialize(content_id:, title:, document_type:, details:, embed_code:)
+    def initialize(content_id:, title:, document_type:, details:, embed_code:, format: nil)
       @content_id = content_id
       @title = title
       @document_type = document_type
       @details = details
       @embed_code = embed_code
+      @format = format || ContentBlockTools::Format::DEFAULT_FORMAT
     end
 
     # Calls the appropriate presenter class to return a HTML representation of a content

--- a/lib/content_block_tools/content_block.rb
+++ b/lib/content_block_tools/content_block.rb
@@ -39,9 +39,6 @@ module ContentBlockTools
   #    content_block_reference.embed_code #=> "{{embed:content_block_contact:2b92cade-549c-4449-9796-e7a3957f3a86/field_name}}"
   #  @return [String]
   class ContentBlock
-    include ActionView::Helpers::TagHelper
-    class UnknownComponentError < StandardError; end
-
     CONTENT_BLOCK_PREFIX = "content_block_".freeze
 
     attr_reader :content_id, :title, :embed_code, :format
@@ -68,7 +65,9 @@ module ContentBlockTools
     # @see GdsApi.content_store
     def self.from_embed_code(embed_code)
       reference = ContentBlockReference.from_string(embed_code)
-      api_response = GdsApi.content_store.content_item(reference.content_store_identifier)
+      api_response = GdsApi.content_store.content_item(
+        reference.content_store_identifier,
+      )
       parsed_embed_code = EmbedCode.new(embed_code)
       new(
         content_id: api_response["content_id"],
@@ -80,7 +79,9 @@ module ContentBlockTools
       )
     end
 
-    def initialize(content_id:, title:, document_type:, details:, embed_code:, format: nil)
+    def initialize(
+      content_id:, title:, document_type:, details:, embed_code:, format: nil
+    )
       @content_id = content_id
       @title = title
       @document_type = document_type
@@ -89,22 +90,12 @@ module ContentBlockTools
       @format = format || ContentBlockTools::Format::DEFAULT_FORMAT
     end
 
-    # Calls the appropriate presenter class to return a HTML representation of a content
-    # block. Defaults to {Presenters::BasePresenter}
+    # Renders the content block to HTML using the appropriate component or presenter
     #
-    # @return [string] A HTML representation of the content block
+    # @return [String] A HTML representation of the content block
+    # @see Renderer
     def render
-      content_tag(
-        base_tag,
-        content,
-        class: %W[content-block content-block--#{document_type}],
-        data: {
-          content_block: "",
-          document_type: document_type,
-          content_id: content_id,
-          embed_code: embed_code,
-        },
-      )
+      Renderer.new(self).render
     end
 
     def details
@@ -113,60 +104,6 @@ module ContentBlockTools
 
     def document_type
       @document_type.delete_prefix(CONTENT_BLOCK_PREFIX)
-    end
-
-  private
-
-    def base_tag
-      rendering_block? ? :div : :span
-    end
-
-    def content
-      field_names.present? ? field_or_block_content : component.new(content_block: self).render
-    rescue UnknownComponentError
-      title
-    end
-
-    def field_or_block_content
-      content = details.dig(*field_names)
-
-      case content
-      when String
-        field_presenter(field_names.last).new(content).render
-      when Hash
-        if embedded_object_in_one_to_one_relationship?
-          field_presenter(field_names.last).new(content).render
-        else
-          component.new(content_block: self, block_type: field_names.first, block_name: field_names.last).render
-        end
-      else
-        ContentBlockTools.logger.warn("Content not found for content block #{content_id} and fields #{field_names}")
-        embed_code
-      end
-    end
-
-    def embedded_object_in_one_to_one_relationship?
-      field_names.one?
-    end
-
-    def rendering_block?
-      !field_names.present? || details.dig(*field_names).is_a?(Hash)
-    end
-
-    def component
-      "ContentBlockTools::#{document_type.camelize}Component".constantize
-    rescue NameError
-      raise UnknownComponentError
-    end
-
-    def field_presenter(field)
-      "ContentBlockTools::Presenters::FieldPresenters::#{document_type.camelize}::#{field.to_s.camelize}Presenter".constantize
-    rescue NameError
-      ContentBlockTools::Presenters::FieldPresenters::BasePresenter
-    end
-
-    def field_names
-      @field_names ||= EmbedCode.new(embed_code).field_names
     end
   end
 end

--- a/lib/content_block_tools/content_block.rb
+++ b/lib/content_block_tools/content_block.rb
@@ -69,13 +69,14 @@ module ContentBlockTools
     def self.from_embed_code(embed_code)
       reference = ContentBlockReference.from_string(embed_code)
       api_response = GdsApi.content_store.content_item(reference.content_store_identifier)
+      parsed_embed_code = EmbedCode.new(embed_code)
       new(
         content_id: api_response["content_id"],
         title: api_response["title"],
         document_type: api_response["document_type"],
         details: api_response["details"],
         embed_code:,
-        format: Format.from_embed_code(embed_code),
+        format: parsed_embed_code.format,
       )
     end
 

--- a/lib/content_block_tools/content_block.rb
+++ b/lib/content_block_tools/content_block.rb
@@ -165,19 +165,7 @@ module ContentBlockTools
     end
 
     def field_names
-      @field_names ||= begin
-        embed_code_match = ContentBlockReference::EMBED_REGEX.match(embed_code)
-        if embed_code_match.present?
-          all_fields = embed_code_match[4]&.reverse&.chomp("/")&.reverse
-          all_fields&.split("/")&.map do |item|
-            is_number?(item) ? item.to_i : item.to_sym
-          end
-        end
-      end
-    end
-
-    def is_number?(item)
-      Float(item, exception: false)
+      @field_names ||= EmbedCode.new(embed_code).field_names
     end
   end
 end

--- a/lib/content_block_tools/content_block_reference.rb
+++ b/lib/content_block_tools/content_block_reference.rb
@@ -41,9 +41,18 @@ module ContentBlockTools
     # The regex used to find content ID aliases
     CONTENT_ID_ALIAS_REGEX = /[a-z0-9\-–—]+/
     # The regex to find optional field names after the UUID, begins with '/'
-    FIELD_REGEX = /(\/[a-z0-9_\-–—\/]*)?/
-    # The regex used when scanning a document using {ContentBlockTools::ContentBlockReference.find_all_in_document}
-    EMBED_REGEX = /({{embed:(#{SUPPORTED_DOCUMENT_TYPES.join('|')}):(#{UUID_REGEX}|#{CONTENT_ID_ALIAS_REGEX})#{FIELD_REGEX}}})/
+    FIELD_REGEX = /(?<fields>\/[a-z0-9_\-–—\/]*)?/
+    # The regex used when scanning a document
+    # @see ContentBlockReference.find_all_in_document
+    EMBED_REGEX = %r{
+      (?<embed_code>
+        \{\{embed:
+        (?<document_type>#{SUPPORTED_DOCUMENT_TYPES.join('|')}):
+        (?<identifier>#{UUID_REGEX}|#{CONTENT_ID_ALIAS_REGEX})
+        #{FIELD_REGEX}
+        \}\}
+      )
+    }x
 
     # Returns if the identifier is an alias
     #
@@ -73,9 +82,11 @@ module ContentBlockTools
       #
       # @return [Array<ContentBlockReference>] An array of content block references
       def find_all_in_document(document)
-        document.scan(EMBED_REGEX).map do |match_data|
-          ContentBlockReference.from_match_data(match_data)
+        results = []
+        document.scan(EMBED_REGEX) do
+          results << ContentBlockReference.from_match_data(Regexp.last_match)
         end
+        results
       end
 
       # Converts a single embed code string into a ContentBlockReference object
@@ -97,7 +108,7 @@ module ContentBlockTools
         match_data = embed_code.match(/^#{EMBED_REGEX}$/)
         raise InvalidEmbedCodeError unless match_data
 
-        ContentBlockReference.from_match_data(match_data.captures)
+        ContentBlockReference.from_match_data(match_data)
       end
 
       # Converts match data from a regex scan into a ContentBlockReference object
@@ -107,8 +118,7 @@ module ContentBlockTools
       # by replacing en/em dashes with double/triple dashes (which can occur due to Kramdown's
       # markdown parsing) before creating the object.
       #
-      # @param match_data [MatchData, Array] the match data from scanning with {EMBED_REGEX}
-      #   Expected to contain: [full_match, document_type, identifier, field]
+      # @param match_data [MatchData] the match data from matching with {EMBED_REGEX}
       # @example Creating from match data
       #   match_data = "{{embed:content_block_pension:2b92cade-549c-4449-9796-e7a3957f3a86}}".match(EMBED_REGEX)
       #   ContentBlockReference.from_match_data(match_data)
@@ -117,27 +127,25 @@ module ContentBlockTools
       # @api private
       # @see find_all_in_document
       # @see from_string
-      # @see prepare_match
       def from_match_data(match_data)
-        match = prepare_match(match_data)
-        ContentBlockTools.logger.info("Found Content Block Reference: #{match}")
-        ContentBlockReference.new(document_type: match[1], identifier: match[2], embed_code: match[0])
+        embed_code = match_data[:embed_code]
+        document_type = match_data[:document_type]
+        identifier = replace_dashes(match_data[:identifier])
+
+        ContentBlockTools.logger.info(
+          "Found Content Block Reference: " \
+          "embed_code=#{embed_code}, " \
+          "document_type=#{document_type}, " \
+          "identifier=#{identifier}",
+        )
+        ContentBlockReference.new(document_type:, identifier:, embed_code:)
       end
 
     private
 
-      # This replaces an en / em dashes in content block references with double or triple dashes. This can occur
+      # This replaces en/em dashes in content block references with double or triple dashes. This can occur
       # because Kramdown (the markdown parser that Govspeak is based on) replaces double dashes with en dashes and
       # triple dashes with em dashes
-      def prepare_match(match)
-        [
-          match[0],
-          match[1],
-          replace_dashes(match[2]),
-          match[3],
-        ]
-      end
-
       def replace_dashes(value)
         value&.gsub("–", "--")
           &.gsub("—", "---")

--- a/lib/content_block_tools/content_block_reference.rb
+++ b/lib/content_block_tools/content_block_reference.rb
@@ -42,6 +42,8 @@ module ContentBlockTools
     CONTENT_ID_ALIAS_REGEX = /[a-z0-9\-–—]+/
     # The regex to find optional field names after the UUID, begins with '/'
     FIELD_REGEX = /(?<fields>\/[a-z0-9_\-–—\/]*)?/
+    # The regex to find optional format specifier, begins with '|'
+    FORMAT_REGEX = /(?:\|(?<format>[a-z0-9_]+))?/
     # The regex used when scanning a document
     # @see ContentBlockReference.find_all_in_document
     EMBED_REGEX = %r{
@@ -50,6 +52,7 @@ module ContentBlockTools
         (?<document_type>#{SUPPORTED_DOCUMENT_TYPES.join('|')}):
         (?<identifier>#{UUID_REGEX}|#{CONTENT_ID_ALIAS_REGEX})
         #{FIELD_REGEX}
+        #{FORMAT_REGEX}
         \}\}
       )
     }x

--- a/lib/content_block_tools/embed_code.rb
+++ b/lib/content_block_tools/embed_code.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module ContentBlockTools
+  # Parses an embed code string and extracts its components.
+  #
+  # An embed code has the format:
+  #   {{embed:document_type:identifier/field/path|format}}
+  #
+  # Where:
+  # - document_type: The type of content block (e.g., content_block_time_period)
+  # - identifier: A UUID or slug identifying the content block
+  # - /field/path: Optional path to a specific field within the content block
+  # - |format: Optional format specifier for rendering
+  #
+  # @example
+  #   embed_code = EmbedCode.new("{{embed:content_block_contact:my-contact/email_addresses/primary/email}}")
+  #   embed_code.field_names #=> [:email_addresses, :primary, :email]
+  #
+  # @example With format
+  #   embed_code = EmbedCode.new("{{embed:content_block_time_period:tax-year|years_short}}")
+  #   embed_code.field_names #=> nil
+  #
+  class EmbedCode
+    # @param embed_code [String] The raw embed code string
+    def initialize(embed_code)
+      @embed_code = embed_code
+    end
+
+    # Extracts the field path from the embed code.
+    #
+    # Parses the embed code to extract any field references after the identifier.
+    # Field references are separated by '/' and can be either symbols or integers
+    # (for array indexing).
+    #
+    # @return [Array<Symbol, Integer>, nil] An array of field names/indices,
+    #   or nil if no fields are specified
+    #
+    # @example
+    #   EmbedCode.new("{{embed:content_block_contact:id/emails/0/address}}").field_names
+    #   #=> [:emails, 0, :address]
+    #
+    def field_names
+      @field_names ||= parse_field_names
+    end
+
+  private
+
+    attr_reader :embed_code
+
+    def parse_field_names
+      match = ContentBlockReference::EMBED_REGEX.match(embed_code)
+      return nil unless match
+
+      raw_fields = match[4]
+      return nil if raw_fields.blank?
+
+      # Remove leading slash and any trailing slash
+      cleaned_fields = raw_fields.sub(%r{^/}, "").sub(%r{/$}, "")
+      return nil if cleaned_fields.blank?
+
+      cleaned_fields.split("/").map do |item|
+        numeric?(item) ? item.to_i : item.to_sym
+      end
+    end
+
+    def numeric?(item)
+      Float(item, exception: false)
+    end
+  end
+end

--- a/lib/content_block_tools/embed_code.rb
+++ b/lib/content_block_tools/embed_code.rb
@@ -18,9 +18,11 @@ module ContentBlockTools
   #
   # @example With format
   #   embed_code = EmbedCode.new("{{embed:content_block_time_period:tax-year|years_short}}")
-  #   embed_code.field_names #=> nil
+  #   embed_code.format #=> "years_short"
   #
   class EmbedCode
+    FORMAT_MATCHER = /\|(?<format>\S+)}}$/
+
     # @param embed_code [String] The raw embed code string
     def initialize(embed_code)
       @embed_code = embed_code
@@ -43,6 +45,21 @@ module ContentBlockTools
       @field_names ||= parse_field_names
     end
 
+    # Extracts the format specifier from the embed code.
+    #
+    # @return [String] The format name, or Format::DEFAULT_FORMAT if none specified
+    #
+    # @example
+    #   EmbedCode.new("{{embed:content_block_time_period:tax-year|years_short}}").format
+    #   #=> "years_short"
+    #
+    #   EmbedCode.new("{{embed:content_block_time_period:tax-year}}").format
+    #   #=> "default"
+    #
+    def format
+      @format ||= parse_format
+    end
+
   private
 
     attr_reader :embed_code
@@ -61,6 +78,13 @@ module ContentBlockTools
       cleaned_fields.split("/").map do |item|
         numeric?(item) ? item.to_i : item.to_sym
       end
+    end
+
+    def parse_format
+      match = FORMAT_MATCHER.match(embed_code)
+      return Format::DEFAULT_FORMAT unless match
+
+      match[:format]
     end
 
     def numeric?(item)

--- a/lib/content_block_tools/embed_code.rb
+++ b/lib/content_block_tools/embed_code.rb
@@ -26,6 +26,7 @@ module ContentBlockTools
     # @param embed_code [String] The raw embed code string
     def initialize(embed_code)
       @embed_code = embed_code
+      @matched_field_names = match_field_names
     end
 
     # Extracts the field path from the embed code.
@@ -65,19 +66,22 @@ module ContentBlockTools
     attr_reader :embed_code
 
     def parse_field_names
-      match = ContentBlockReference::EMBED_REGEX.match(embed_code)
-      return nil unless match
+      return nil unless @matched_field_names
 
-      raw_fields = match[4]
-      return nil if raw_fields.blank?
-
-      # Remove leading slash and any trailing slash
-      cleaned_fields = raw_fields.sub(%r{^/}, "").sub(%r{/$}, "")
-      return nil if cleaned_fields.blank?
-
-      cleaned_fields.split("/").map do |item|
+      @matched_field_names.split("/").map do |item|
         numeric?(item) ? item.to_i : item.to_sym
       end
+    end
+
+    def match_field_names
+      match = ContentBlockReference::EMBED_REGEX.match(embed_code)
+      return unless match && match[:fields]
+
+      stripped_of_trailing_or_leading_slashes(match[:fields])
+    end
+
+    def stripped_of_trailing_or_leading_slashes(string)
+      string.sub(%r{^/}, "").sub(%r{/$}, "")
     end
 
     def parse_format

--- a/lib/content_block_tools/format.rb
+++ b/lib/content_block_tools/format.rb
@@ -1,0 +1,13 @@
+module ContentBlockTools
+  module Format
+    MATCHER = Regexp.new(/\|(?<format>\S+)}}$/)
+    DEFAULT_FORMAT = "default".freeze
+
+    def self.from_embed_code(embed_code)
+      match = MATCHER.match(embed_code)
+      return DEFAULT_FORMAT unless match
+
+      match[:format]
+    end
+  end
+end

--- a/lib/content_block_tools/format.rb
+++ b/lib/content_block_tools/format.rb
@@ -1,13 +1,5 @@
 module ContentBlockTools
   module Format
-    MATCHER = Regexp.new(/\|(?<format>\S+)}}$/)
     DEFAULT_FORMAT = "default".freeze
-
-    def self.from_embed_code(embed_code)
-      match = MATCHER.match(embed_code)
-      return DEFAULT_FORMAT unless match
-
-      match[:format]
-    end
   end
 end

--- a/lib/content_block_tools/renderer.rb
+++ b/lib/content_block_tools/renderer.rb
@@ -1,0 +1,119 @@
+module ContentBlockTools
+  # Handles rendering of ContentBlock instances to HTML
+  #
+  # The Renderer is responsible for:
+  # - Resolving the appropriate component or presenter for a content block
+  # - Generating the HTML wrapper with appropriate data attributes
+  # - Handling field-specific rendering when embed codes target specific fields
+  #
+  # @api private
+  class Renderer
+    include ActionView::Helpers::TagHelper
+
+    class UnknownComponentError < StandardError; end
+
+    # Creates a new Renderer for the given content block
+    #
+    # @param content_block [ContentBlock] The content block to render
+    def initialize(content_block)
+      @content_block = content_block
+    end
+
+    # Renders the content block to HTML
+    #
+    # @return [String] HTML representation of the content block
+    def render
+      content_tag(
+        base_tag,
+        content,
+        class: %W[content-block content-block--#{document_type}],
+        data: {
+          content_block: "",
+          document_type: document_type,
+          content_id: content_id,
+          embed_code: embed_code,
+        },
+      )
+    end
+
+  private
+
+    attr_reader :content_block
+
+    delegate :content_id, :title, :embed_code, :details, :document_type, :format,
+             to: :content_block
+
+    def base_tag
+      rendering_block? ? :div : :span
+    end
+
+    def content
+      if field_names.present?
+        field_or_block_content
+      else
+        component.new(content_block: content_block).render
+      end
+    rescue UnknownComponentError
+      title
+    end
+
+    def field_or_block_content
+      field_content = details.dig(*field_names)
+
+      case field_content
+      when String
+        field_presenter(field_names.last).new(field_content).render
+      when Hash
+        render_hash_content
+      else
+        log_missing_content_warning
+        embed_code
+      end
+    end
+
+    def render_hash_content
+      if embedded_object_in_one_to_one_relationship?
+        field_presenter(field_names.last).new(details.dig(*field_names)).render
+      else
+        component.new(
+          content_block: content_block,
+          block_type: field_names.first,
+          block_name: field_names.last,
+        ).render
+      end
+    end
+
+    def log_missing_content_warning
+      ContentBlockTools.logger.warn(
+        "Content not found for content block #{content_id} and fields #{field_names}",
+      )
+    end
+
+    def embedded_object_in_one_to_one_relationship?
+      field_names.one?
+    end
+
+    def rendering_block?
+      !field_names.present? || details.dig(*field_names).is_a?(Hash)
+    end
+
+    def component
+      "ContentBlockTools::#{document_type.camelize}Component".constantize
+    rescue NameError
+      raise UnknownComponentError
+    end
+
+    def field_presenter(field)
+      presenter_class_name =
+        "ContentBlockTools::Presenters::FieldPresenters::" \
+        "#{document_type.camelize}::#{field.to_s.camelize}Presenter"
+      presenter_class_name.constantize
+    rescue NameError
+      ContentBlockTools::Presenters::FieldPresenters::BasePresenter
+    end
+
+    def field_names
+      @field_names ||= EmbedCode.new(embed_code).field_names
+    end
+  end
+end

--- a/spec/content_block_tools/components/content_block_tools/time_period_component_spec.rb
+++ b/spec/content_block_tools/components/content_block_tools/time_period_component_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe ContentBlockTools::TimePeriodComponent do
       }
     end
 
+    let(:format) { nil }
+
     let(:content_block) do
       ContentBlockTools::ContentBlock.new(
         document_type: "time_period",
@@ -16,6 +18,7 @@ RSpec.describe ContentBlockTools::TimePeriodComponent do
         title: "Tax year",
         details: details,
         embed_code: "{{embed:content_block_time_period:tax-year}}",
+        format: format,
       )
     end
 
@@ -23,19 +26,144 @@ RSpec.describe ContentBlockTools::TimePeriodComponent do
       described_class.new(content_block: content_block)
     end
 
-    it "presents the date range as pair of GovUK formatted dates" do
-      expect(component.render).to have_tag(
-        "p",
-        with: { class: "govuk-body" },
-        seen: "6 April 2025 to 5 April 2026",
-      )
+    context "with default format" do
+      it "presents the date range as pair of GovUK formatted dates" do
+        expect(component.render).to have_tag(
+          "p",
+          with: { class: "govuk-body" },
+          seen: "6 April 2025 to 5 April 2026",
+        )
+      end
+
+      context "when the date range is not defined" do
+        let(:details) { {} }
+
+        it "renders nothing" do
+          expect(component.render).not_to have_tag("p")
+        end
+      end
     end
 
-    context "when the date range is not defined" do
-      let(:details) { {} }
+    context "with explicit default format" do
+      let(:format) { "default" }
 
-      it "renders nothing" do
-        expect(component.render).not_to have_tag("p")
+      it "presents the full date range" do
+        expect(component.render).to have_tag(
+          "p",
+          with: { class: "govuk-body" },
+          seen: "6 April 2025 to 5 April 2026",
+        )
+      end
+    end
+
+    context "with long_form format" do
+      let(:format) { "long_form" }
+
+      it "presents month and year range" do
+        expect(component.render).to have_tag(
+          "p",
+          with: { class: "govuk-body" },
+          seen: "April 2025 to April 2026",
+        )
+      end
+
+      context "when the date range is not defined" do
+        let(:details) { {} }
+
+        it "renders nothing" do
+          expect(component.render).not_to have_tag("p")
+        end
+      end
+    end
+
+    context "with start_day_and_month format" do
+      let(:format) { "start_day_and_month" }
+
+      it "presents the start day and month only" do
+        expect(component.render).to have_tag(
+          "p",
+          with: { class: "govuk-body" },
+          seen: "6 April",
+        )
+      end
+
+      context "when the date range is not defined" do
+        let(:details) { {} }
+
+        it "renders nothing" do
+          expect(component.render).not_to have_tag("p")
+        end
+      end
+    end
+
+    context "with start_month_as_word format" do
+      let(:format) { "start_month_as_word" }
+
+      it "presents the start month only" do
+        expect(component.render).to have_tag(
+          "p",
+          with: { class: "govuk-body" },
+          seen: "April",
+        )
+      end
+
+      context "when the date range is not defined" do
+        let(:details) { {} }
+
+        it "renders nothing" do
+          expect(component.render).not_to have_tag("p")
+        end
+      end
+    end
+
+    context "with years format" do
+      let(:format) { "years" }
+
+      it "presents the year range with full years" do
+        expect(component.render).to have_tag(
+          "p",
+          with: { class: "govuk-body" },
+          seen: "2025-2026",
+        )
+      end
+
+      context "when the date range is not defined" do
+        let(:details) { {} }
+
+        it "renders nothing" do
+          expect(component.render).not_to have_tag("p")
+        end
+      end
+    end
+
+    context "with years_short format" do
+      let(:format) { "years_short" }
+
+      it "presents the year range with abbreviated end year" do
+        expect(component.render).to have_tag(
+          "p",
+          with: { class: "govuk-body" },
+          seen: "2025-26",
+        )
+      end
+
+      context "when the date range is not defined" do
+        let(:details) { {} }
+
+        it "renders nothing" do
+          expect(component.render).not_to have_tag("p")
+        end
+      end
+    end
+
+    context "with an invalid format" do
+      let(:format) { "unknown_format" }
+
+      it "raises an InvalidFormatError" do
+        expect { component }.to raise_error(
+          ContentBlockTools::InvalidFormatError,
+          "Unknown format 'unknown_format' for time_period",
+        )
       end
     end
   end

--- a/spec/content_block_tools/content_block_reference_spec.rb
+++ b/spec/content_block_tools/content_block_reference_spec.rb
@@ -139,6 +139,33 @@ RSpec.describe ContentBlockTools::ContentBlockReference do
             expect(result[2].embed_code).to eq("{{embed:content_block_pension:#{content_block_pension_uuid}/another-field}}")
           end
         end
+
+        context "when there are format specifiers in the embed code" do
+          let(:time_period_uuid) { SecureRandom.uuid }
+
+          let(:document) do
+            "
+              {{embed:content_block_time_period:#{time_period_uuid}|years}}
+              {{embed:content_block_time_period:#{time_period_uuid}|years_short}}
+            ".squish
+          end
+
+          it "finds all the references including format specifier" do
+            expect(result.count).to eq(2)
+
+            expect(result[0].document_type).to eq("content_block_time_period")
+            expect(result[0].identifier).to eq(time_period_uuid)
+            expect(result[0].embed_code).to eq(
+              "{{embed:content_block_time_period:#{time_period_uuid}|years}}",
+            )
+
+            expect(result[1].document_type).to eq("content_block_time_period")
+            expect(result[1].identifier).to eq(time_period_uuid)
+            expect(result[1].embed_code).to eq(
+              "{{embed:content_block_time_period:#{time_period_uuid}|years_short}}",
+            )
+          end
+        end
       end
     end
 
@@ -233,6 +260,26 @@ RSpec.describe ContentBlockTools::ContentBlockReference do
 
       expect(result.document_type).to eq("content_block_pension")
       expect(result.identifier).to eq("my-pension")
+      expect(result.embed_code).to eq(embed_code)
+    end
+
+    it "converts an embed code with a format specifier" do
+      embed_code = "{{embed:content_block_time_period:tax-year|years_short}}"
+
+      result = described_class.from_string(embed_code)
+
+      expect(result.document_type).to eq("content_block_time_period")
+      expect(result.identifier).to eq("tax-year")
+      expect(result.embed_code).to eq(embed_code)
+    end
+
+    it "converts an embed code with fields and a format specifier" do
+      embed_code = "{{embed:content_block_contact:my-contact/email|default}}"
+
+      result = described_class.from_string(embed_code)
+
+      expect(result.document_type).to eq("content_block_contact")
+      expect(result.identifier).to eq("my-contact")
       expect(result.embed_code).to eq(embed_code)
     end
 

--- a/spec/content_block_tools/content_block_reference_spec.rb
+++ b/spec/content_block_tools/content_block_reference_spec.rb
@@ -79,8 +79,8 @@ RSpec.describe ContentBlockTools::ContentBlockReference do
 
       describe "#content_references" do
         it "returns all references" do
-          expect(ContentBlockTools.logger).to receive(:info).with("Found Content Block Reference: [\"{{embed:contact:#{contact_uuid}}}\", \"contact\", \"#{contact_uuid}\", nil]")
-          expect(ContentBlockTools.logger).to receive(:info).with("Found Content Block Reference: [\"{{embed:content_block_pension:#{content_block_pension_uuid}}}\", \"content_block_pension\", \"#{content_block_pension_uuid}\", nil]")
+          expect(ContentBlockTools.logger).to receive(:info).with("Found Content Block Reference: embed_code={{embed:contact:#{contact_uuid}}}, document_type=contact, identifier=#{contact_uuid}")
+          expect(ContentBlockTools.logger).to receive(:info).with("Found Content Block Reference: embed_code={{embed:content_block_pension:#{content_block_pension_uuid}}}, document_type=content_block_pension, identifier=#{content_block_pension_uuid}")
 
           expect(result.count).to eq(2)
 
@@ -155,8 +155,8 @@ RSpec.describe ContentBlockTools::ContentBlockReference do
 
       describe "#content_references" do
         it "returns all references" do
-          expect(ContentBlockTools.logger).to receive(:info).with("Found Content Block Reference: [\"{{embed:contact:#{contact_alias}}}\", \"contact\", \"#{contact_alias}\", nil]")
-          expect(ContentBlockTools.logger).to receive(:info).with("Found Content Block Reference: [\"{{embed:content_block_pension:#{content_block_pension_alias}}}\", \"content_block_pension\", \"#{content_block_pension_alias}\", nil]")
+          expect(ContentBlockTools.logger).to receive(:info).with("Found Content Block Reference: embed_code={{embed:contact:#{contact_alias}}}, document_type=contact, identifier=#{contact_alias}")
+          expect(ContentBlockTools.logger).to receive(:info).with("Found Content Block Reference: embed_code={{embed:content_block_pension:#{content_block_pension_alias}}}, document_type=content_block_pension, identifier=#{content_block_pension_alias}")
 
           expect(result.count).to eq(2)
 

--- a/spec/content_block_tools/content_block_spec.rb
+++ b/spec/content_block_tools/content_block_spec.rb
@@ -41,9 +41,13 @@ RSpec.describe ContentBlockTools::ContentBlock do
     let(:content_store_identifier) { "/content-blocks/content_block_pension/my-pension" }
     let(:content_block) { double(ContentBlockTools::ContentBlock) }
     let(:content_store) { double(GdsApi::ContentStore) }
+    let(:expected_format) { double("expected_format") }
 
     before do
       allow(GdsApi).to receive(:content_store).and_return(content_store)
+      allow(ContentBlockTools::Format).to receive(:from_embed_code).and_return(
+        expected_format,
+      )
     end
 
     it "returns a content block" do
@@ -64,6 +68,43 @@ RSpec.describe ContentBlockTools::ContentBlock do
       expect(content_block.title).to eq(api_response["title"])
       expect(content_block.details).to eq(api_response["details"].deep_symbolize_keys)
       expect(content_block.document_type).to eq("pension")
+      expect(content_block.format).to eql(expected_format)
+    end
+  end
+
+  describe "#format" do
+    context "when a format is provided" do
+      let(:content_block) do
+        described_class.new(
+          document_type: document_type,
+          content_id: content_id,
+          title: title,
+          details: details,
+          embed_code: embed_code,
+          format: "years_short",
+        )
+      end
+
+      it "returns the format provided" do
+        expect(content_block.format).to eq("years_short")
+      end
+    end
+
+    context "when a format is NOT provided" do
+      let(:content_block) do
+        described_class.new(
+          document_type: document_type,
+          content_id: content_id,
+          title: title,
+          details: details,
+          embed_code: embed_code,
+          format: nil,
+        )
+      end
+
+      it "returns the ContentBlockTools::Format::DEFAULT_FORMAT" do
+        expect(content_block.format).to eq(ContentBlockTools::Format::DEFAULT_FORMAT)
+      end
     end
   end
 

--- a/spec/content_block_tools/content_block_spec.rb
+++ b/spec/content_block_tools/content_block_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ContentBlockTools::ContentBlock do
     expect(content_block.details).to eq(details)
   end
 
-  describe "#from_embed_code" do
+  describe "::from_embed_code" do
     let(:embed_code) { "{{embed:content_block_pension:my-pension}}" }
     let(:api_response) do
       {
@@ -67,7 +67,7 @@ RSpec.describe ContentBlockTools::ContentBlock do
     end
   end
 
-  describe ".details" do
+  describe "#details" do
     let(:details) do
       {
         "foo" => {
@@ -83,7 +83,7 @@ RSpec.describe ContentBlockTools::ContentBlock do
     end
   end
 
-  describe ".render" do
+  describe "#render" do
     context "with a contact block" do
       let(:expected_wrapper_attributes) do
         {

--- a/spec/content_block_tools/content_block_spec.rb
+++ b/spec/content_block_tools/content_block_spec.rb
@@ -41,13 +41,9 @@ RSpec.describe ContentBlockTools::ContentBlock do
     let(:content_store_identifier) { "/content-blocks/content_block_pension/my-pension" }
     let(:content_block) { double(ContentBlockTools::ContentBlock) }
     let(:content_store) { double(GdsApi::ContentStore) }
-    let(:expected_format) { double("expected_format") }
 
     before do
       allow(GdsApi).to receive(:content_store).and_return(content_store)
-      allow(ContentBlockTools::Format).to receive(:from_embed_code).and_return(
-        expected_format,
-      )
     end
 
     it "returns a content block" do
@@ -68,7 +64,28 @@ RSpec.describe ContentBlockTools::ContentBlock do
       expect(content_block.title).to eq(api_response["title"])
       expect(content_block.details).to eq(api_response["details"].deep_symbolize_keys)
       expect(content_block.document_type).to eq("pension")
-      expect(content_block.format).to eql(expected_format)
+      expect(content_block.format).to eq(ContentBlockTools::Format::DEFAULT_FORMAT)
+    end
+
+    context "when the embed code includes a format" do
+      let(:embed_code) { "{{embed:content_block_pension:my-pension|custom_format}}" }
+
+      it "extracts the format from the embed code" do
+        expect(ContentBlockTools::ContentBlockReference).to receive(:from_string)
+                                                              .with(embed_code)
+                                                              .and_return(reference)
+
+        expect(reference).to receive(:content_store_identifier)
+                               .and_return(content_store_identifier)
+
+        expect(content_store).to receive(:content_item)
+                                   .with(content_store_identifier)
+                                   .and_return(api_response)
+
+        content_block = ContentBlockTools::ContentBlock.from_embed_code(embed_code)
+
+        expect(content_block.format).to eq("custom_format")
+      end
     end
   end
 

--- a/spec/content_block_tools/embed_code_spec.rb
+++ b/spec/content_block_tools/embed_code_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+RSpec.describe ContentBlockTools::EmbedCode do
+  describe "#field_names" do
+    context "when embed code has no field path" do
+      it "returns nil" do
+        embed_code = described_class.new("{{embed:content_block_contact:my-contact}}")
+        expect(embed_code.field_names).to be_nil
+      end
+    end
+
+    context "when embed code has a single field" do
+      it "returns an array with that field as a symbol" do
+        embed_code = described_class.new("{{embed:content_block_contact:my-contact/email}}")
+        expect(embed_code.field_names).to eq([:email])
+      end
+    end
+
+    context "when embed code has multiple fields" do
+      it "returns an array of symbols" do
+        embed_code = described_class.new(
+          "{{embed:content_block_contact:my-contact/email_addresses/primary/email}}",
+        )
+        expect(embed_code.field_names).to eq(%i[email_addresses primary email])
+      end
+    end
+
+    context "when embed code has numeric field (array index)" do
+      it "returns integers for numeric fields" do
+        embed_code = described_class.new(
+          "{{embed:content_block_contact:my-contact/email_addresses/0/email}}",
+        )
+        expect(embed_code.field_names).to eq([:email_addresses, 0, :email])
+      end
+    end
+
+    context "when embed code has a trailing slash" do
+      it "ignores the trailing slash" do
+        embed_code = described_class.new(
+          "{{embed:content_block_time_period:tax-year/date_range/}}",
+        )
+        expect(embed_code.field_names).to eq([:date_range])
+      end
+    end
+
+    context "when embed code has a format specifier" do
+      it "still parses field names correctly (format is not part of field path)" do
+        # NOTE: The current EMBED_REGEX doesn't account for format specifier,
+        # so field_names may include the format. This test documents current behaviour.
+        embed_code = described_class.new(
+          "{{embed:content_block_time_period:tax-year|years_short}}",
+        )
+        expect(embed_code.field_names).to be_nil
+      end
+    end
+
+    context "when embed code is invalid" do
+      it "returns nil for non-matching embed codes" do
+        embed_code = described_class.new("not an embed code")
+        expect(embed_code.field_names).to be_nil
+      end
+    end
+
+    context "when embed code uses UUID identifier" do
+      it "parses field names correctly" do
+        uuid = "2b92cade-549c-4449-9796-e7a3957f3a86"
+        embed_code = described_class.new(
+          "{{embed:content_block_pension:#{uuid}/rates/basic}}",
+        )
+        expect(embed_code.field_names).to eq(%i[rates basic])
+      end
+    end
+  end
+end

--- a/spec/content_block_tools/embed_code_spec.rb
+++ b/spec/content_block_tools/embed_code_spec.rb
@@ -71,4 +71,38 @@ RSpec.describe ContentBlockTools::EmbedCode do
       end
     end
   end
+
+  describe "#format" do
+    context "when embed code has a format specifier" do
+      it "returns the format name" do
+        embed_code = described_class.new(
+          "{{embed:content_block_time_period:tax-year|years_short}}",
+        )
+        expect(embed_code.format).to eq("years_short")
+      end
+
+      it "handles format with field path" do
+        embed_code = described_class.new(
+          "{{embed:content_block_contact:main_office/telephones/telephone|hmrc_full}}",
+        )
+        expect(embed_code.format).to eq("hmrc_full")
+      end
+    end
+
+    context "when embed code has no format specifier" do
+      it "returns the default format" do
+        embed_code = described_class.new(
+          "{{embed:content_block_contact:main_office}}",
+        )
+        expect(embed_code.format).to eq(ContentBlockTools::Format::DEFAULT_FORMAT)
+      end
+
+      it "returns default format when embed code has field path but no format" do
+        embed_code = described_class.new(
+          "{{embed:content_block_contact:main_office/telephones/telephone}}",
+        )
+        expect(embed_code.format).to eq(ContentBlockTools::Format::DEFAULT_FORMAT)
+      end
+    end
+  end
 end

--- a/spec/content_block_tools/format_spec.rb
+++ b/spec/content_block_tools/format_spec.rb
@@ -1,0 +1,52 @@
+RSpec.describe ContentBlockTools::Format do
+  describe "::from_embed_code(embed_code)" do
+    context "when the embed code ends with a format demarcated by '*|format_name'" do
+      let(:examples) do
+        [
+          { embed_code: "{{embed:content_block:time_period:tax-year|years_short}}",
+            format: "years_short" },
+
+          { embed_code: "{{embed:content_block:time_period:tax-year|years}}",
+            format: "years" },
+
+          { embed_code: "{{embed:content_block_contact:main_office/telephones/telephone|hmrc_full}}",
+            format: "hmrc_full" },
+        ]
+      end
+
+      it "returns that format, as found" do
+        aggregate_failures do
+          examples.each do |example|
+            format_derived = ContentBlockTools::Format.from_embed_code(example.fetch(:embed_code))
+
+            expect(format_derived).to eq(
+              example.fetch(:format),
+            ), "expected '#{example.fetch(:format)}' from embed_code '#{example.fetch(:embed_code)}' " \
+              "(received #{format_derived})"
+          end
+        end
+      end
+    end
+
+    context "when the embed code does NOT end with a format demarcated by '*|format_name'" do
+      let(:examples) do
+        %w[
+          {{embed:content_block_contact:main_office}}
+          {{embed:content_block_contact:main_office/telephones/telephone}}
+        ]
+      end
+
+      it "returns the DEFAULT_FORMAT" do
+        aggregate_failures do
+          examples.each do |embed_code|
+            format_derived = ContentBlockTools::Format.from_embed_code(embed_code)
+
+            expect(format_derived).to eq(
+              ContentBlockTools::Format::DEFAULT_FORMAT,
+            ), "expected 'default' format from embed_code '#{embed_code}' (received #{format_derived})"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/content_block_tools/format_spec.rb
+++ b/spec/content_block_tools/format_spec.rb
@@ -1,52 +1,7 @@
 RSpec.describe ContentBlockTools::Format do
-  describe "::from_embed_code(embed_code)" do
-    context "when the embed code ends with a format demarcated by '*|format_name'" do
-      let(:examples) do
-        [
-          { embed_code: "{{embed:content_block:time_period:tax-year|years_short}}",
-            format: "years_short" },
-
-          { embed_code: "{{embed:content_block:time_period:tax-year|years}}",
-            format: "years" },
-
-          { embed_code: "{{embed:content_block_contact:main_office/telephones/telephone|hmrc_full}}",
-            format: "hmrc_full" },
-        ]
-      end
-
-      it "returns that format, as found" do
-        aggregate_failures do
-          examples.each do |example|
-            format_derived = ContentBlockTools::Format.from_embed_code(example.fetch(:embed_code))
-
-            expect(format_derived).to eq(
-              example.fetch(:format),
-            ), "expected '#{example.fetch(:format)}' from embed_code '#{example.fetch(:embed_code)}' " \
-              "(received #{format_derived})"
-          end
-        end
-      end
-    end
-
-    context "when the embed code does NOT end with a format demarcated by '*|format_name'" do
-      let(:examples) do
-        %w[
-          {{embed:content_block_contact:main_office}}
-          {{embed:content_block_contact:main_office/telephones/telephone}}
-        ]
-      end
-
-      it "returns the DEFAULT_FORMAT" do
-        aggregate_failures do
-          examples.each do |embed_code|
-            format_derived = ContentBlockTools::Format.from_embed_code(embed_code)
-
-            expect(format_derived).to eq(
-              ContentBlockTools::Format::DEFAULT_FORMAT,
-            ), "expected 'default' format from embed_code '#{embed_code}' (received #{format_derived})"
-          end
-        end
-      end
+  describe "DEFAULT_FORMAT" do
+    it "is 'default'" do
+      expect(ContentBlockTools::Format::DEFAULT_FORMAT).to eq("default")
     end
   end
 end

--- a/spec/content_block_tools/renderer_spec.rb
+++ b/spec/content_block_tools/renderer_spec.rb
@@ -1,0 +1,271 @@
+RSpec.describe ContentBlockTools::Renderer do
+  let(:content_id) { SecureRandom.uuid }
+  let(:title) { "Some Title" }
+  let(:document_type) { "content_block_pension" }
+  let(:details) { { some: "details" } }
+  let(:embed_code) { "{{embed:content_block_pension:something}}" }
+  let(:format) { ContentBlockTools::Format::DEFAULT_FORMAT }
+
+  let(:content_block) do
+    ContentBlockTools::ContentBlock.new(
+      document_type:,
+      content_id:,
+      title:,
+      details:,
+      embed_code:,
+      format:,
+    )
+  end
+
+  let(:renderer) { described_class.new(content_block) }
+
+  describe "#render" do
+    context "with a contact block" do
+      let(:expected_wrapper_attributes) do
+        {
+          class: "content-block content-block--contact",
+          "data-content-block" => "",
+          "data-document-type" => "contact",
+          "data-content-id" => content_id,
+          "data-embed-code" => embed_code,
+        }
+      end
+
+      let(:details) do
+        {
+          email_addresses: {
+            something: {
+              title: "Title",
+              email: "foo@bar.com",
+            },
+          },
+        }
+      end
+
+      let(:document_type) { "content_block_contact" }
+
+      context "when embed code does not include any field or block references" do
+        let(:embed_code) { "{{embed:content_block_contact:contact}}" }
+
+        it "renders with the component" do
+          expect(ContentBlockTools::ContactComponent)
+            .to receive_message_chain(:new, :render)
+                  .with(content_block:)
+                  .with(no_args)
+                  .and_return("CONTENT_BLOCK_CONTENT")
+
+          expect(renderer.render).to have_tag("div", text: "CONTENT_BLOCK_CONTENT", with: expected_wrapper_attributes)
+        end
+      end
+
+      context "when embed code references a block" do
+        let(:embed_code) { "{{embed:content_block_contact:contact/email_addresses/something}}" }
+
+        it "initializes the component with the block type and block name and renders" do
+          expect(ContentBlockTools::ContactComponent)
+            .to receive_message_chain(:new, :render)
+                  .with(content_block:, block_type: "email_addresses", block_name: "something")
+                  .with(no_args)
+                  .and_return("CONTENT_BLOCK_CONTENT")
+
+          expect(renderer.render).to have_tag("div", text: "CONTENT_BLOCK_CONTENT", with: expected_wrapper_attributes)
+        end
+      end
+
+      context "when embed code references an email field" do
+        let(:embed_code) { "{{embed:content_block_contact:contact/email_addresses/something/email}}" }
+
+        it "uses the presenter to render the field" do
+          expect(ContentBlockTools::Presenters::FieldPresenters::Contact::EmailPresenter)
+            .to receive_message_chain(:new, :render)
+                  .with("foo@bar.com")
+                  .with(no_args)
+                  .and_return("foo@bar.com")
+
+          expect(renderer.render).to have_tag("span", text: "foo@bar.com", with: expected_wrapper_attributes)
+        end
+      end
+
+      context "when embed code references another field" do
+        let(:embed_code) { "{{embed:content_block_contact:contact/email_addresses/something/title}}" }
+
+        it "uses the base presenter to render the field" do
+          expect(ContentBlockTools::Presenters::FieldPresenters::BasePresenter)
+            .to receive_message_chain(:new, :render)
+                  .with("title")
+                  .with(no_args)
+                  .and_return("title")
+
+          expect(renderer.render).to have_tag("span", text: "title", with: expected_wrapper_attributes)
+        end
+      end
+
+      context "when embed code references a non-existent field" do
+        let(:embed_code) { "{{embed:content_block_contact:contact/email_addresses/something/bleh}}" }
+
+        it "logs a warning and returns the embed code" do
+          expect(ContentBlockTools.logger).to receive(:warn)
+            .with("Content not found for content block #{content_id} and fields [:email_addresses, :something, :bleh]")
+
+          expect(renderer.render).to have_tag("span", text: embed_code, with: expected_wrapper_attributes)
+        end
+      end
+    end
+
+    context "with a time period block" do
+      let(:document_type) { "content_block_time_period" }
+
+      let(:expected_wrapper_attributes) do
+        {
+          class: "content-block content-block--time_period",
+          "data-content-block" => "",
+          "data-document-type" => "time_period",
+          "data-content-id" => content_id,
+          "data-embed-code" => embed_code,
+        }
+      end
+
+      let(:details) do
+        {
+          date_range: {
+            start: {
+              date: "2022-01-01",
+              time: "00:00",
+            },
+            end: {
+              date: "2022-12-31",
+              time: "23:59",
+            },
+          },
+        }
+      end
+
+      context "when embed code references the start date" do
+        let(:embed_code) { "{{embed:content_block_time_period:current-calendar-year/date_range/start/date}}" }
+
+        it "uses the date presenter to render the field" do
+          expect(ContentBlockTools::Presenters::FieldPresenters::TimePeriod::DatePresenter)
+            .to receive_message_chain(:new, :render)
+                  .with("2022-01-01")
+                  .with(no_args)
+                  .and_return("1 January 2022")
+
+          expect(renderer.render).to have_tag("span", text: "1 January 2022", with: expected_wrapper_attributes)
+        end
+      end
+
+      context "when embed code references the start time" do
+        let(:embed_code) { "{{embed:content_block_time_period:current-calendar-year/date_range/start/time}}" }
+
+        it "uses the time presenter to render the field" do
+          expect(ContentBlockTools::Presenters::FieldPresenters::TimePeriod::TimePresenter)
+            .to receive_message_chain(:new, :render)
+                  .with("00:00")
+                  .with(no_args)
+                  .and_return("midnight")
+
+          expect(renderer.render).to have_tag("span", text: "midnight", with: expected_wrapper_attributes)
+        end
+      end
+
+      context "when embed code does not include field references" do
+        let(:embed_code) { "{{embed:content_block_time_period:current-calendar-year}}" }
+
+        it "renders with the component" do
+          expect(ContentBlockTools::TimePeriodComponent)
+            .to receive_message_chain(:new, :render)
+                  .with(content_block:)
+                  .with(no_args)
+                  .and_return("6 April 2025 to 5 April 2026")
+
+          expect(renderer.render).to have_tag("div", text: "6 April 2025 to 5 April 2026", with: expected_wrapper_attributes)
+        end
+      end
+    end
+
+    context "with a pension block (no component)" do
+      let(:document_type) { "content_block_pension" }
+      let(:title) { "State Pension" }
+
+      let(:expected_wrapper_attributes) do
+        {
+          class: "content-block content-block--pension",
+          "data-content-block" => "",
+          "data-document-type" => "pension",
+          "data-content-id" => content_id,
+          "data-embed-code" => embed_code,
+        }
+      end
+
+      let(:details) do
+        {
+          rates: {
+            "full-basic-state-pension": {
+              amount: "£123.45",
+            },
+          },
+        }
+      end
+
+      context "when embed code does not include any field or block references" do
+        let(:embed_code) { "{{embed:content_block_pension:pension}}" }
+
+        it "returns the content block's title when no component exists" do
+          expect(renderer.render).to have_tag("div", text: title, with: expected_wrapper_attributes)
+        end
+      end
+
+      context "when embed code references a field" do
+        let(:embed_code) { "{{embed:content_block_pension:pension/rates/full-basic-state-pension/amount}}" }
+
+        it "uses the base presenter to render the field" do
+          expect(ContentBlockTools::Presenters::FieldPresenters::BasePresenter)
+            .to receive_message_chain(:new, :render)
+                  .with("amount")
+                  .with(no_args)
+                  .and_return("£123.45")
+
+          expect(renderer.render).to have_tag("span", text: "£123.45", with: expected_wrapper_attributes)
+        end
+      end
+    end
+
+    describe "HTML wrapper attributes" do
+      let(:document_type) { "content_block_time_period" }
+      let(:embed_code) { "{{embed:content_block_time_period:tax-year}}" }
+      let(:details) do
+        {
+          date_range: {
+            start: { date: "2025-04-06", time: "00:00" },
+            end: { date: "2026-04-05", time: "23:59" },
+          },
+        }
+      end
+
+      before do
+        allow(ContentBlockTools::TimePeriodComponent)
+          .to receive_message_chain(:new, :render)
+          .and_return("content")
+      end
+
+      it "includes the correct data attributes" do
+        rendered = renderer.render
+
+        expect(rendered).to have_tag("div", with: {
+          "data-content-block" => "",
+          "data-document-type" => "time_period",
+          "data-content-id" => content_id,
+          "data-embed-code" => embed_code,
+        })
+      end
+
+      it "includes the correct CSS classes" do
+        rendered = renderer.render
+
+        expect(rendered).to have_tag("div", with: {
+          class: "content-block content-block--time_period",
+        })
+      end
+    end
+  end
+end


### PR DESCRIPTION
At present ContentBlockTools (this gem) renders representations of "content" based on:  
  
- a given "embed code"  
- a given "details" representation of content  
  
Every piece of "content" is represented by a "details" hash in which where the keys are field names and the values are either pieces of content or other key-value pairs (or collections of key-value pairs).  
  
### Current behaviour  
  
For a simple content block of type `TimePeriod`, when we instantiate a `ContentBlock` with the following `embed_code` and `details`:  
  
EMBED CODE: `{{embed:content_block_time_period:tax-year}}`  
  
DETAILS:  
  
```rb  
{    
  "date_range" => {    
    "start" => { "date" => "2025-04-06", "time" => "00:00" },    
    "end" => { "date" => "2026-04-05", "time" => "23:59" },    
},  }  
```  
  
like this:  
  
```rb
ContentBlockTools::ContentBlock.new(
    document_type: "time_period",
    content_id: SecureRandom.uuid,
    title: "Tax year",
    details: details,
    embed_code: "{{embed:content_block_time_period:tax-year}}",
)
```

and we create a "component" (Rails [ViewComponent](https://viewcomponent.org/)\) with this content_block, the component's `render` method generates output as follows:  
  
RENDERED_OUTPUT:  

```html
<p class="govuk-body">
    6 April 2025
    to
    5 April 2026
</p>
```    

  
### Desired behaviour  
  
We want to develop the behaviour of this gem so that we can allow users to present a range of different representations of a block, which we'll call "formats". 

In this experimental PR we propose a way of doing this by passing in variants of an embed code which include a segment describing the desired "format" of the output to be generated. e.g.  
  
```  
{{embed:content_block_time_period:tax-year|long_form}}  
-> April 2025 to April 2026  
  
{{embed:content_block_time_period:tax-year|start_day_and_month}}  
-> 4 April  
  
{{embed:content_block_time_period:tax-year|start_month_as_word}}  
-> April  
  
{{embed:content_block_time_period:tax-year|years}}  
-> 2025-2026  
  
{{embed:content_block_time_period:tax-year|years_short}}  
-> 2025-26  
```  
  
To do this, in this PR we reduce the responsibilities of the `ContentBlock` class by:

- introducing a new `EmbedCode` class for parsing embed codes
- introducing a new `Renderer` class for determining which component to use to render the representation suited to the embed code

We also:
- use named rather than positional captures in our embed code regexes to make the code a bit clearer
- introduce the cucumber testing library as a development dependency and use a cucumber feature to describe format rendering at a high level
