### PR TITLE
CM-825: Validate time period date range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 1.11.0
+
+* Add dual-format support for `TimePeriod#date_range` - accepts both legacy nested 
+  format and ISO 8601 strings
+* 
 ## 1.10.4
 
 * Update dependencies

--- a/app/components/content_block_tools/time_period_component.rb
+++ b/app/components/content_block_tools/time_period_component.rb
@@ -2,25 +2,28 @@ module ContentBlockTools
   class TimePeriodComponent < ContentBlockTools::BaseComponent
     def initialize(content_block:, _block_type: nil, _block_name: nil)
       @content_block = content_block
+      @normalised_date_range = normalise_date_range
     end
 
     def start_date
-      presented_date(
-        content_block.details.dig(:date_range, :start, :date),
-      )
+      presented_date(normalised_date_range.start_date)
     end
 
     def end_date
-      presented_date(
-        content_block.details.dig(:date_range, :end, :date),
-      )
+      presented_date(normalised_date_range.end_date)
     end
 
   private
 
-    attr_reader :content_block
+    attr_reader :content_block, :normalised_date_range
+
+    def normalise_date_range
+      NormalisedDateRange.new(content_block.details[:date_range])
+    end
 
     def presented_date(date)
+      return unless date.present?
+
       Presenters::FieldPresenters::TimePeriod::DatePresenter.new(
         date,
       ).render

--- a/lib/content_block_tools.rb
+++ b/lib/content_block_tools.rb
@@ -13,6 +13,8 @@ require "content_block_tools/presenters/field_presenters/contact/email_presenter
 require "content_block_tools/presenters/field_presenters/time_period/date_range_presenter"
 require "content_block_tools/presenters/field_presenters/time_period/date_presenter"
 require "content_block_tools/presenters/field_presenters/time_period/time_presenter"
+require "content_block_tools/presenters/field_presenters/time_period/start_presenter"
+require "content_block_tools/presenters/field_presenters/time_period/end_presenter"
 
 require "content_block_tools/content_block"
 require "content_block_tools/content_block_reference"

--- a/lib/content_block_tools.rb
+++ b/lib/content_block_tools.rb
@@ -16,6 +16,7 @@ require "content_block_tools/presenters/field_presenters/time_period/time_presen
 
 require "content_block_tools/content_block"
 require "content_block_tools/content_block_reference"
+require "content_block_tools/normalised_date_range"
 
 require "content_block_tools/engine"
 

--- a/lib/content_block_tools/normalised_date_range.rb
+++ b/lib/content_block_tools/normalised_date_range.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module ContentBlockTools
+  class NormalisedDateRange
+    class ParseError < StandardError; end
+
+    def initialize(date_range)
+      @date_range = date_range || {}
+    end
+
+    def start_time
+      @start_time ||= parse_value(date_range[:start])
+    end
+
+    def end_time
+      @end_time ||= parse_value(date_range[:end])
+    end
+
+    def start_date
+      start_time&.to_date
+    end
+
+    def end_date
+      end_time&.to_date
+    end
+
+  private
+
+    attr_reader :date_range
+
+    def parse_value(value)
+      return nil if value.blank?
+
+      if value.is_a?(Hash)
+        parse_legacy_format(value)
+      else
+        parse_iso8601_format(value)
+      end
+    end
+
+    def parse_legacy_format(value)
+      date_string = value[:date]
+      time_string = value[:time]
+
+      return nil if date_string.blank?
+
+      # Validate date with Date.parse (stricter than Time.zone.parse)
+      Date.parse(date_string)
+
+      datetime_string = [date_string, time_string].compact.join(" ")
+      Time.zone.parse(datetime_string)
+    rescue Date::Error
+      raise ParseError, "Invalid legacy date format: #{value.inspect}"
+    end
+
+    def parse_iso8601_format(datetime_string)
+      result = Time.zone.parse(datetime_string)
+      raise ParseError, "Invalid ISO 8601 format: #{datetime_string.inspect}" if result.nil?
+
+      result
+    end
+  end
+end

--- a/lib/content_block_tools/presenters/field_presenters/time_period/date_presenter.rb
+++ b/lib/content_block_tools/presenters/field_presenters/time_period/date_presenter.rb
@@ -6,8 +6,23 @@ module ContentBlockTools
           def render
             return unless field.present?
 
-            date = Date.parse(field)
-            date.strftime("%e %B %Y").strip
+            time = field.is_a?(String) ? parsed_string : field
+
+            time.strftime("%e %B %Y").strip
+          rescue Date::Error
+            nil
+          end
+
+        private
+
+          def parsed_string
+            validate_string_representation
+
+            Time.zone.parse(field)
+          end
+
+          def validate_string_representation
+            Date.parse(field)
           end
         end
       end

--- a/lib/content_block_tools/presenters/field_presenters/time_period/date_range_presenter.rb
+++ b/lib/content_block_tools/presenters/field_presenters/time_period/date_range_presenter.rb
@@ -5,25 +5,38 @@ module ContentBlockTools
         class TimePeriodPresenterError < RuntimeError; end
 
         class DateRangePresenter < BasePresenter
+          def initialize(field, **args)
+            super
+            @normalised_date_range = normalise_date_range
+          end
+
           def render
             return unless start_date.present? && end_date.present?
 
             "#{start_date} to #{end_date}"
-          rescue Date::Error, TypeError
-            raise TimePeriodPresenterError, "Not a valid date range: #{field}"
+          rescue NormalisedDateRange::ParseError => e
+            raise TimePeriodPresenterError, "Not a valid date range: #{field} (#{e.message})"
           end
 
         private
 
+          attr_reader :normalised_date_range
+
           def start_date
-            presented_date(field.dig(:start, :date))
+            presented_date(normalised_date_range.start_date)
           end
 
           def end_date
-            presented_date(field.dig(:end, :date))
+            presented_date(normalised_date_range.end_date)
+          end
+
+          def normalise_date_range
+            NormalisedDateRange.new(field)
           end
 
           def presented_date(date)
+            return unless date.present?
+
             Presenters::FieldPresenters::TimePeriod::DatePresenter.new(
               date,
             ).render

--- a/lib/content_block_tools/presenters/field_presenters/time_period/end_presenter.rb
+++ b/lib/content_block_tools/presenters/field_presenters/time_period/end_presenter.rb
@@ -1,0 +1,17 @@
+module ContentBlockTools
+  module Presenters
+    module FieldPresenters
+      module TimePeriod
+        class EndPresenter < BasePresenter
+          def render
+            return unless field.present?
+
+            Presenters::FieldPresenters::TimePeriod::DatePresenter.new(
+              field,
+            ).render
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/content_block_tools/presenters/field_presenters/time_period/start_presenter.rb
+++ b/lib/content_block_tools/presenters/field_presenters/time_period/start_presenter.rb
@@ -1,0 +1,17 @@
+module ContentBlockTools
+  module Presenters
+    module FieldPresenters
+      module TimePeriod
+        class StartPresenter < BasePresenter
+          def render
+            return unless field.present?
+
+            Presenters::FieldPresenters::TimePeriod::DatePresenter.new(
+              field,
+            ).render
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "1.10.4"
+  VERSION = "1.11.0"
 end

--- a/spec/content_block_tools/components/content_block_tools/time_period_component_spec.rb
+++ b/spec/content_block_tools/components/content_block_tools/time_period_component_spec.rb
@@ -1,14 +1,5 @@
 RSpec.describe ContentBlockTools::TimePeriodComponent do
   describe "#render" do
-    let(:details) do
-      {
-        "date_range" => {
-          "start" => { "date" => "2025-04-06", "time" => "00:00" },
-          "end" => { "date" => "2026-04-05", "time" => "23:59" },
-        },
-      }
-    end
-
     let(:content_block) do
       ContentBlockTools::ContentBlock.new(
         document_type: "time_period",
@@ -23,12 +14,85 @@ RSpec.describe ContentBlockTools::TimePeriodComponent do
       described_class.new(content_block: content_block)
     end
 
-    it "presents the date range as pair of GovUK formatted dates" do
-      expect(component.render).to have_tag(
-        "p",
-        with: { class: "govuk-body" },
-        seen: "6 April 2025 to 5 April 2026",
-      )
+    context "with legacy format" do
+      let(:details) do
+        {
+          "date_range" => {
+            "start" => { "date" => "2025-04-06", "time" => "00:00" },
+            "end" => { "date" => "2026-04-05", "time" => "23:59" },
+          },
+        }
+      end
+
+      it "presents the date range as pair of GovUK formatted dates" do
+        expect(component.render).to have_tag(
+          "p",
+          with: { class: "govuk-body" },
+          seen: "6 April 2025 to 5 April 2026",
+        )
+      end
+    end
+
+    context "with ISO 8601 format" do
+      let(:details) do
+        {
+          "date_range" => {
+            "start" => "2025-04-06T00:00:00+00:00",
+            "end" => "2026-04-05T23:59:00+00:00",
+          },
+        }
+      end
+
+      it "presents the date range as pair of GovUK formatted dates" do
+        expect(component.render).to have_tag(
+          "p",
+          with: { class: "govuk-body" },
+          seen: "6 April 2025 to 5 April 2026",
+        )
+      end
+    end
+
+    context "when both formats produce identical output" do
+      let(:legacy_details) do
+        {
+          "date_range" => {
+            "start" => { "date" => "2025-04-06", "time" => "00:00" },
+            "end" => { "date" => "2026-04-05", "time" => "23:59" },
+          },
+        }
+      end
+
+      let(:iso8601_details) do
+        {
+          "date_range" => {
+            "start" => "2025-04-06T00:00:00+00:00",
+            "end" => "2026-04-05T23:59:00+00:00",
+          },
+        }
+      end
+
+      it "renders the same output for both formats" do
+        legacy_block = ContentBlockTools::ContentBlock.new(
+          document_type: "time_period",
+          content_id: SecureRandom.uuid,
+          title: "Tax year",
+          details: legacy_details,
+          embed_code: "{{embed:content_block_time_period:tax-year}}",
+        )
+
+        iso8601_block = ContentBlockTools::ContentBlock.new(
+          document_type: "time_period",
+          content_id: SecureRandom.uuid,
+          title: "Tax year",
+          details: iso8601_details,
+          embed_code: "{{embed:content_block_time_period:tax-year}}",
+        )
+
+        legacy_component = described_class.new(content_block: legacy_block)
+        iso8601_component = described_class.new(content_block: iso8601_block)
+
+        expect(legacy_component.render).to eq(iso8601_component.render)
+      end
     end
 
     context "when the date range is not defined" do

--- a/spec/content_block_tools/normalised_date_range_spec.rb
+++ b/spec/content_block_tools/normalised_date_range_spec.rb
@@ -1,0 +1,220 @@
+RSpec.describe ContentBlockTools::NormalisedDateRange do
+  describe "legacy format" do
+    let(:date_range) do
+      {
+        start: { date: "2025-04-06", time: "00:00" },
+        end: { date: "2026-04-05", time: "23:59" },
+      }
+    end
+
+    it "returns the start time as a Time object" do
+      normalised = described_class.new(date_range)
+
+      expect(normalised.start_time).to be_a(ActiveSupport::TimeWithZone)
+      expect(normalised.start_time).to eq(Time.zone.parse("2025-04-06 00:00"))
+    end
+
+    it "returns the end time as a Time object" do
+      normalised = described_class.new(date_range)
+
+      expect(normalised.end_time).to be_a(ActiveSupport::TimeWithZone)
+      expect(normalised.end_time).to eq(Time.zone.parse("2026-04-05 23:59"))
+    end
+
+    it "returns the start date as a Date object" do
+      normalised = described_class.new(date_range)
+
+      expect(normalised.start_date).to eq(Date.new(2025, 4, 6))
+    end
+
+    it "returns the end date as a Date object" do
+      normalised = described_class.new(date_range)
+
+      expect(normalised.end_date).to eq(Date.new(2026, 4, 5))
+    end
+
+    context "when time is missing" do
+      let(:date_range) do
+        {
+          start: { date: "2025-04-06" },
+          end: { date: "2026-04-05" },
+        }
+      end
+
+      it "parses with date only" do
+        normalised = described_class.new(date_range)
+
+        expect(normalised.start_date).to eq(Date.new(2025, 4, 6))
+        expect(normalised.end_date).to eq(Date.new(2026, 4, 5))
+      end
+    end
+  end
+
+  describe "ISO 8601 format" do
+    let(:date_range) do
+      {
+        start: "2025-04-06T00:00:00+00:00",
+        end: "2026-04-05T23:59:00+00:00",
+      }
+    end
+
+    it "returns the start time as a Time object" do
+      normalised = described_class.new(date_range)
+
+      expect(normalised.start_time).to be_a(ActiveSupport::TimeWithZone)
+      expect(normalised.start_time).to eq(Time.zone.parse("2025-04-06T00:00:00+00:00"))
+    end
+
+    it "returns the end time as a Time object" do
+      normalised = described_class.new(date_range)
+
+      expect(normalised.end_time).to be_a(ActiveSupport::TimeWithZone)
+      expect(normalised.end_time).to eq(Time.zone.parse("2026-04-05T23:59:00+00:00"))
+    end
+
+    it "returns the start date as a Date object" do
+      normalised = described_class.new(date_range)
+
+      expect(normalised.start_date).to eq(Date.new(2025, 4, 6))
+    end
+
+    it "returns the end date as a Date object" do
+      normalised = described_class.new(date_range)
+
+      expect(normalised.end_date).to eq(Date.new(2026, 4, 5))
+    end
+
+    context "with non-UTC timezone offset" do
+      let(:date_range) do
+        {
+          start: "2025-04-06T00:00:00+01:00",
+          end: "2026-04-05T23:59:00+01:00",
+        }
+      end
+
+      it "preserves the original time (converted to zone)" do
+        normalised = described_class.new(date_range)
+
+        # +01:00 at midnight becomes 23:00 previous day in UTC
+        expect(normalised.start_time.utc.hour).to eq(23)
+        expect(normalised.start_time.utc.day).to eq(5)
+      end
+    end
+  end
+
+  describe "format consistency" do
+    let(:legacy_format) do
+      {
+        start: { date: "2025-04-06", time: "00:00" },
+        end: { date: "2026-04-05", time: "23:59" },
+      }
+    end
+
+    let(:iso8601_format) do
+      {
+        start: "2025-04-06T00:00:00+00:00",
+        end: "2026-04-05T23:59:00+00:00",
+      }
+    end
+
+    it "produces identical dates from both formats" do
+      legacy = described_class.new(legacy_format)
+      iso8601 = described_class.new(iso8601_format)
+
+      expect(legacy.start_date).to eq(iso8601.start_date)
+      expect(legacy.end_date).to eq(iso8601.end_date)
+    end
+  end
+
+  describe "missing or empty data" do
+    context "when date_range is nil" do
+      it "returns nil for all values" do
+        normalised = described_class.new(nil)
+
+        expect(normalised.start_time).to be_nil
+        expect(normalised.end_time).to be_nil
+        expect(normalised.start_date).to be_nil
+        expect(normalised.end_date).to be_nil
+      end
+    end
+
+    context "when date_range is empty" do
+      it "returns nil for all values" do
+        normalised = described_class.new({})
+
+        expect(normalised.start_time).to be_nil
+        expect(normalised.end_time).to be_nil
+        expect(normalised.start_date).to be_nil
+        expect(normalised.end_date).to be_nil
+      end
+    end
+
+    context "when start is missing" do
+      let(:date_range) do
+        { end: "2026-04-05T23:59:00+01:00" }
+      end
+
+      it "returns nil for start values" do
+        normalised = described_class.new(date_range)
+
+        expect(normalised.start_time).to be_nil
+        expect(normalised.start_date).to be_nil
+        expect(normalised.end_time).to be_present
+      end
+    end
+
+    context "when legacy format date field is blank" do
+      let(:date_range) do
+        {
+          start: { date: "", time: "00:00" },
+          end: { date: "2026-04-05", time: "23:59" },
+        }
+      end
+
+      it "returns nil for the blank endpoint" do
+        normalised = described_class.new(date_range)
+
+        expect(normalised.start_time).to be_nil
+        expect(normalised.start_date).to be_nil
+      end
+    end
+  end
+
+  describe "error handling" do
+    context "when ISO 8601 string is invalid" do
+      let(:date_range) do
+        {
+          start: "not-a-date",
+          end: "2026-04-05T23:59:00+01:00",
+        }
+      end
+
+      it "raises a ParseError" do
+        normalised = described_class.new(date_range)
+
+        expect { normalised.start_time }.to raise_error(
+          ContentBlockTools::NormalisedDateRange::ParseError,
+          /Invalid ISO 8601 format/,
+        )
+      end
+    end
+
+    context "when legacy format date is invalid" do
+      let(:date_range) do
+        {
+          start: { date: "not-a-date", time: "00:00" },
+          end: { date: "2026-04-05", time: "23:59" },
+        }
+      end
+
+      it "raises a ParseError" do
+        normalised = described_class.new(date_range)
+
+        expect { normalised.start_time }.to raise_error(
+          ContentBlockTools::NormalisedDateRange::ParseError,
+          /Invalid legacy date format/,
+        )
+      end
+    end
+  end
+end

--- a/spec/content_block_tools/presenters/field_presenters/time_period/date_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/field_presenters/time_period/date_presenter_spec.rb
@@ -1,13 +1,57 @@
 RSpec.describe ContentBlockTools::Presenters::FieldPresenters::TimePeriod::DatePresenter do
-  it "presents a date" do
-    date = "2023-01-01"
+  context "when the given param is a string representation" do
+    context "and the string is a well formed date" do
+      it "presents a date" do
+        string = "2023-01-01"
 
-    presenter = described_class.new(date)
+        presenter = described_class.new(string)
 
-    expect(presenter.render).to eq("1 January 2023")
+        expect(presenter.render).to eq("1 January 2023")
+      end
+    end
+
+    context "and the string is a well formed time" do
+      it "presents a date" do
+        string = "2023-01-01T00:00:00+00:00"
+
+        presenter = described_class.new(string)
+
+        expect(presenter.render).to eq("1 January 2023")
+      end
+    end
+
+    context "and the string is badly formed" do
+      it "returns nil" do
+        string = "not-a-date"
+
+        presenter = described_class.new(string)
+
+        expect(presenter.render).to be_nil
+      end
+    end
+
+    context "and the string is an impossible date" do
+      it "returns nil" do
+        string = "2025-02-30"
+
+        presenter = described_class.new(string)
+
+        expect(presenter.render).to be_nil
+      end
+    end
   end
 
-  context "when the date is not defined" do
+  context "when the given param is a Time object (via NormalisedDateRange)" do
+    it "presents a date" do
+      time = Time.zone.parse("2023-01-01T000:00:00+00:00")
+
+      presenter = described_class.new(time)
+
+      expect(presenter.render).to eq("1 January 2023")
+    end
+  end
+
+  context "when the param is nil" do
     it "renders nothing" do
       presenter = described_class.new(nil)
 

--- a/spec/content_block_tools/presenters/field_presenters/time_period/date_range_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/field_presenters/time_period/date_range_presenter_spec.rb
@@ -1,21 +1,61 @@
 RSpec.describe ContentBlockTools::Presenters::FieldPresenters::TimePeriod::DateRangePresenter do
-  let(:date_range) do
-    {
-      start: {
-        date: "2025-04-06",
-        time: "00:00",
-      },
-      end: {
-        date: "2026-04-05",
-        time: "23:59",
-      },
-    }
+  describe "with legacy format" do
+    let(:date_range) do
+      {
+        start: {
+          date: "2025-04-06",
+          time: "00:00",
+        },
+        end: {
+          date: "2026-04-05",
+          time: "23:59",
+        },
+      }
+    end
+
+    it "presents a date range in words, omitting time" do
+      presenter = described_class.new(date_range)
+
+      expect(presenter.render).to eq("6 April 2025 to 5 April 2026")
+    end
   end
 
-  it "presents a date range in words, omitting time" do
-    presenter = described_class.new(date_range)
+  describe "with ISO 8601 format" do
+    let(:date_range) do
+      {
+        start: "2025-04-06T00:00:00+00:00",
+        end: "2026-04-05T23:59:00+00:00",
+      }
+    end
 
-    expect(presenter.render).to eq("6 April 2025 to 5 April 2026")
+    it "presents a date range in words, omitting time" do
+      presenter = described_class.new(date_range)
+
+      expect(presenter.render).to eq("6 April 2025 to 5 April 2026")
+    end
+  end
+
+  describe "format consistency" do
+    let(:legacy_format) do
+      {
+        start: { date: "2025-04-06", time: "00:00" },
+        end: { date: "2026-04-05", time: "23:59" },
+      }
+    end
+
+    let(:iso8601_format) do
+      {
+        start: "2025-04-06T00:00:00+00:00",
+        end: "2026-04-05T23:59:00+00:00",
+      }
+    end
+
+    it "produces identical output for both formats" do
+      legacy = described_class.new(legacy_format)
+      iso8601 = described_class.new(iso8601_format)
+
+      expect(legacy.render).to eq(iso8601.render)
+    end
   end
 
   context "when the date range is not defined" do
@@ -44,7 +84,7 @@ RSpec.describe ContentBlockTools::Presenters::FieldPresenters::TimePeriod::DateR
       end
     end
 
-    context "when the value found can't be parsed as a date" do
+    context "when the legacy format date can't be parsed" do
       let(:date_range) do
         {
           start: {
@@ -63,7 +103,25 @@ RSpec.describe ContentBlockTools::Presenters::FieldPresenters::TimePeriod::DateR
 
         expect { presenter.render }.to raise_error(
           ContentBlockTools::Presenters::FieldPresenters::TimePeriod::TimePeriodPresenterError,
-          "Not a valid date range: #{date_range}",
+          /Not a valid date range:.*Invalid legacy date format/,
+        )
+      end
+    end
+
+    context "when the ISO 8601 format is invalid" do
+      let(:date_range) do
+        {
+          start: "not-a-date",
+          end: "2026-04-05T23:59:00+00:00",
+        }
+      end
+
+      it "raises an error with an informative message" do
+        presenter = described_class.new(date_range)
+
+        expect { presenter.render }.to raise_error(
+          ContentBlockTools::Presenters::FieldPresenters::TimePeriod::TimePeriodPresenterError,
+          /Not a valid date range:.*Invalid ISO 8601 format/,
         )
       end
     end

--- a/spec/content_block_tools/presenters/field_presenters/time_period/end_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/field_presenters/time_period/end_presenter_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe ContentBlockTools::Presenters::FieldPresenters::TimePeriod::EndPresenter do
+  around do |example|
+    Time.use_zone("London") { example.run }
+  end
+
+  it "presents an end datetime as a formatted date" do
+    datetime = "2026-04-05T23:59:00+01:00"
+
+    presenter = described_class.new(datetime)
+
+    expect(presenter.render).to eq("5 April 2026")
+  end
+
+  it "handles datetimes with different timezones" do
+    datetime = "2023-12-31T23:59:59+00:00"
+
+    presenter = described_class.new(datetime)
+
+    expect(presenter.render).to eq("31 December 2023")
+  end
+
+  context "when the datetime is not defined" do
+    it "renders nothing" do
+      presenter = described_class.new(nil)
+
+      expect(presenter.render).to be_nil
+    end
+  end
+
+  context "when the datetime is blank" do
+    it "renders nothing" do
+      presenter = described_class.new("")
+
+      expect(presenter.render).to be_nil
+    end
+  end
+end

--- a/spec/content_block_tools/presenters/field_presenters/time_period/start_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/field_presenters/time_period/start_presenter_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe ContentBlockTools::Presenters::FieldPresenters::TimePeriod::StartPresenter do
+  around do |example|
+    Time.use_zone("London") { example.run }
+  end
+
+  it "presents a start datetime as a formatted date" do
+    datetime = "2025-04-06T00:00:00+01:00"
+
+    presenter = described_class.new(datetime)
+
+    expect(presenter.render).to eq("6 April 2025")
+  end
+
+  it "handles datetimes with different timezones" do
+    datetime = "2023-12-25T14:30:00+00:00"
+
+    presenter = described_class.new(datetime)
+
+    expect(presenter.render).to eq("25 December 2023")
+  end
+
+  context "when the datetime is not defined" do
+    it "renders nothing" do
+      presenter = described_class.new(nil)
+
+      expect(presenter.render).to be_nil
+    end
+  end
+
+  context "when the datetime is blank" do
+    it "renders nothing" do
+      presenter = described_class.new("")
+
+      expect(presenter.render).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
See Jira [CM-825: Validate TimePeriod#date_range](https://gov-uk.atlassian.net/browse/CM-825)

In this PR we extend this gem to support dual-running of both current and future formats of `TimePeriod#date_range`.

We're changing TimePeriod.date_range to be:
```
- start: datetime
- end: datetime
```
rather than:

```
- start:
  - date: date
  - time: time

- end:
  - date: date
  - time: time
```
This will make the work of validating user input a little simpler, in
that for:

- validation
- serialision/deserialision

we'll be acting on a pair of datetimes, without the additional step of
decomposing to date and time values, which have no useful function on
their own.

We've prepared a new version of the ContentBlockTools gem which supports
both forms to make it safe to introduce the change.

## Our overall deployment plan 

Is as follows:

1. extend "tools" to support new TimePeriod#date_range structure whilst
  remain backwards compatible with the original structure (**this PR**)

2. release data migration on Content Block Manager to convert existing
  TimePeriods to new structure

3. change Content Block Manager to create and edit Time Periods with new
  structure

4. remove support for the old Time Period structure from "tools"


