### PR TITLE
Fix: date extraction from ISO 8601 datetimes with timezone offsets

### DIFF
--- a/lib/content_block_tools/normalised_date_range.rb
+++ b/lib/content_block_tools/normalised_date_range.rb
@@ -54,10 +54,9 @@ module ContentBlockTools
     end
 
     def parse_iso8601_format(datetime_string)
-      result = Time.zone.parse(datetime_string)
-      raise ParseError, "Invalid ISO 8601 format: #{datetime_string.inspect}" if result.nil?
-
-      result
+      Time.parse(datetime_string)
+    rescue ArgumentError
+      raise ParseError, "Invalid ISO 8601 format: #{datetime_string.inspect}"
     end
   end
 end

--- a/spec/content_block_tools/normalised_date_range_spec.rb
+++ b/spec/content_block_tools/normalised_date_range_spec.rb
@@ -53,23 +53,23 @@ RSpec.describe ContentBlockTools::NormalisedDateRange do
   describe "ISO 8601 format" do
     let(:date_range) do
       {
-        start: "2025-04-06T00:00:00+00:00",
-        end: "2026-04-05T23:59:00+00:00",
+        start: "2025-04-06T00:00:00+01:00",
+        end: "2026-04-05T23:59:00+01:00",
       }
     end
 
     it "returns the start time as a Time object" do
       normalised = described_class.new(date_range)
 
-      expect(normalised.start_time).to be_a(ActiveSupport::TimeWithZone)
-      expect(normalised.start_time).to eq(Time.zone.parse("2025-04-06T00:00:00+00:00"))
+      expect(normalised.start_time).to be_a(Time)
+      expect(normalised.start_time).to eq(Time.parse("2025-04-06T00:00:00+01:00"))
     end
 
     it "returns the end time as a Time object" do
       normalised = described_class.new(date_range)
 
-      expect(normalised.end_time).to be_a(ActiveSupport::TimeWithZone)
-      expect(normalised.end_time).to eq(Time.zone.parse("2026-04-05T23:59:00+00:00"))
+      expect(normalised.end_time).to be_a(Time)
+      expect(normalised.end_time).to eq(Time.parse("2026-04-05T23:59:00+01:00"))
     end
 
     it "returns the start date as a Date object" do
@@ -92,12 +92,11 @@ RSpec.describe ContentBlockTools::NormalisedDateRange do
         }
       end
 
-      it "preserves the original time (converted to zone)" do
+      it "extracts the date from the original timezone, not UTC" do
         normalised = described_class.new(date_range)
 
-        # +01:00 at midnight becomes 23:00 previous day in UTC
-        expect(normalised.start_time.utc.hour).to eq(23)
-        expect(normalised.start_time.utc.day).to eq(5)
+        expect(normalised.start_date).to eq(Date.new(2025, 4, 6))
+        expect(normalised.end_date).to eq(Date.new(2026, 4, 5))
       end
     end
   end
@@ -112,8 +111,8 @@ RSpec.describe ContentBlockTools::NormalisedDateRange do
 
     let(:iso8601_format) do
       {
-        start: "2025-04-06T00:00:00+00:00",
-        end: "2026-04-05T23:59:00+00:00",
+        start: "2025-04-06T00:00:00+01:00",
+        end: "2026-04-05T23:59:00+01:00",
       }
     end
 


### PR DESCRIPTION
## Fix bug parsing `datetime` fields in `TimePeriod#date_range`

This is unlikely to be an issue in publishing apps which have their timezone set to "London" but was causing a test failure locally within the gem's test suite.

This illustrates the issue:

```
    Time.zone = "UTC"
    Time.zone.parse("2025-04-06T00:00:00+01:00").to_date
    => Sat, 05 Apr 2025

    Time.zone = "London"
    Time.zone.parse("2025-04-06T00:00:00+01:00").to_date
    => Sun, 06 Apr 2025
```
and the fix:

```
    Time.zone = "UTC"
    Time.parse("2025-04-06T00:00:00+01:00").to_date
    => Sun, 06 Apr 2025

    Time.zone = "London"
    Time.parse("2025-04-06T00:00:00+01:00").to_date
    => Sun, 06 Apr 2025
```

We now use Time.parse instead of Time.zone.parse for ISO 8601 strings to preserve the original timezone offset. This ensures that when a user enters '6 April 2025 at 00:00' in the UK (BST), the date extracted is 6 April, not 5 April (which would happen if converted to UTC first).

GOV.UK apps have mixed timezone configurations: Publishing Apps use London timezone, while API Services use UTC. When Time.zone is UTC, Time.zone.parse('2025-04-06T00:00:00+01:00') converts to UTC (23:00 on April 5th), and .to_date returns the wrong date.

Using Time.parse instead preserves whatever offset is in the ISO 8601 string, making this gem work correctly regardless of the host app's timezone configuration.

See: https://docs.publishing.service.gov.uk/repos/govuk_app_config/adr/0001-timezone-usage-across-gov-uk.html


