### PR TITLE
CM-865: Refactoring to introduce EmbedCode and Renderer

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,8 +3,10 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 require "rubocop/rake_task"
+require "cucumber/rake/task"
 
 RuboCop::RakeTask.new
 RSpec::Core::RakeTask.new(:spec)
+Cucumber::Rake::Task.new(:cucumber)
 
-task default: %i[rubocop spec]
+task default: %i[rubocop spec cucumber]

--- a/content_block_tools.gemspec
+++ b/content_block_tools.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]
 
+  spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake", "13.4.2"
   spec.add_development_dependency "rspec-html-matchers", "0.10.0"
   spec.add_development_dependency "rspec-rails"

--- a/content_block_tools.gemspec
+++ b/content_block_tools.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]
 
+  spec.add_development_dependency "cucumber", "~> 9.2"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake", "13.4.2"
   spec.add_development_dependency "rspec-html-matchers", "0.10.0"

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,0 +1,1 @@
+default: --format pretty

--- a/features/contact_rendering.feature
+++ b/features/contact_rendering.feature
@@ -1,0 +1,13 @@
+Feature: Contact rendering
+  So that users can easily identify and use contact information
+  As a content editor
+  I want contact blocks to render in full
+
+  Scenario: Contact renders with default formatting
+    Given a contact content block with the following details:
+      | field   | value                    |
+      | email   | contact@example.gov.uk   |
+      | phone   | 020 7946 0958            |
+      | address | 10 Downing St, London    |
+    When I render the content block
+    Then I should see the complete contact details within a vcard

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -1,0 +1,3 @@
+When("I render the content block") do
+  @rendered = @content_block.render
+end

--- a/features/step_definitions/contact_steps.rb
+++ b/features/step_definitions/contact_steps.rb
@@ -1,0 +1,58 @@
+Given("a contact content block with the following details:") do |table|
+  details = table.rows_hash.transform_keys(&:to_sym)
+
+  @content_block = ContentBlockTools::ContentBlock.new(
+    document_type: "content_block_contact",
+    content_id: SecureRandom.uuid,
+    title: "Test Contact",
+    details: {
+      email_addresses: {
+        main: {
+          title: "Email",
+          email_address: details[:email],
+        },
+      },
+      telephones: {
+        main: {
+          title: "Phone",
+          telephone_numbers: [
+            { label: "Telephone", telephone_number: details[:phone] },
+          ],
+        },
+      },
+      addresses: {
+        main: {
+          title: "Address",
+          street_address: details[:address],
+        },
+      },
+      order: %w[email_addresses.main telephones.main addresses.main],
+    },
+    embed_code: "{{embed:content_block_contact:test-contact}}",
+  )
+end
+
+Then("I should see the complete contact details within a vcard") do
+  expect(@rendered).to have_tag("div.content-block.content-block--contact") do
+    with_tag("div.vcard") do
+      with_tag "div", with: { "data-diff-key" => "email_addresses-main" } do
+        with_tag("dt", seen: "Email")
+        with_tag(
+          "a",
+          with: { href: "mailto:contact@example.gov.uk" },
+          seen: "contact@example.gov.uk",
+        )
+      end
+
+      with_tag "div", with: { "data-diff-key" => "telephones-main" } do
+        with_tag("dt", seen: "Phone")
+        with_tag("dd", seen: "Telephone: 020 7946 0958")
+      end
+
+      with_tag "div", with: { "data-diff-key" => "addresses-main" } do
+        with_tag("dt", seen: "Address")
+        with_tag("dd", seen: "10 Downing St, London")
+      end
+    end
+  end
+end

--- a/features/step_definitions/time_period_steps.rb
+++ b/features/step_definitions/time_period_steps.rb
@@ -1,0 +1,20 @@
+Given("a time period content block exists") do
+  @content_block = ContentBlockTools::ContentBlock.new(
+    document_type: "content_block_time_period",
+    content_id: SecureRandom.uuid,
+    title: "Current tax year",
+    details: {
+      date_range: {
+        start: "2025-04-06T00:00:00+01:00",
+        end: "2026-04-05T23:59:00+01:00",
+      },
+    },
+    embed_code: "{{embed:content_block_time_period:current-tax-year}}",
+  )
+end
+
+Then("I should see the time period displayed in the default long form") do
+  expect(@rendered).to have_tag("div.content-block.content-block--time_period") do
+    with_tag("p", seen: "6 April 2025 to 5 April 2026")
+  end
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,0 +1,4 @@
+require File.expand_path("../../spec/dummy/config/environment", __dir__)
+require "rspec-html-matchers"
+
+World(RSpecHtmlMatchers)

--- a/features/time_period_rendering.feature
+++ b/features/time_period_rendering.feature
@@ -1,0 +1,9 @@
+Feature: Time period rendering
+  So that users can easily understand date ranges
+  As a content editor
+  I want time period blocks to render with GDS style formatting
+
+  Scenario: Time period renders with default formatting
+    Given a time period content block exists
+    When I render the content block
+    Then I should see the time period displayed in the default long form

--- a/lib/content_block_tools.rb
+++ b/lib/content_block_tools.rb
@@ -18,6 +18,7 @@ require "content_block_tools/presenters/field_presenters/time_period/end_present
 
 require "content_block_tools/content_block"
 require "content_block_tools/content_block_reference"
+require "content_block_tools/embed_code"
 require "content_block_tools/normalised_date_range"
 
 require "content_block_tools/engine"

--- a/lib/content_block_tools.rb
+++ b/lib/content_block_tools.rb
@@ -20,6 +20,7 @@ require "content_block_tools/content_block"
 require "content_block_tools/content_block_reference"
 require "content_block_tools/embed_code"
 require "content_block_tools/normalised_date_range"
+require "content_block_tools/renderer"
 
 require "content_block_tools/engine"
 

--- a/lib/content_block_tools/content_block.rb
+++ b/lib/content_block_tools/content_block.rb
@@ -163,19 +163,7 @@ module ContentBlockTools
     end
 
     def field_names
-      @field_names ||= begin
-        embed_code_match = ContentBlockReference::EMBED_REGEX.match(embed_code)
-        if embed_code_match.present?
-          all_fields = embed_code_match[4]&.reverse&.chomp("/")&.reverse
-          all_fields&.split("/")&.map do |item|
-            is_number?(item) ? item.to_i : item.to_sym
-          end
-        end
-      end
-    end
-
-    def is_number?(item)
-      Float(item, exception: false)
+      @field_names ||= EmbedCode.new(embed_code).field_names
     end
   end
 end

--- a/lib/content_block_tools/content_block.rb
+++ b/lib/content_block_tools/content_block.rb
@@ -39,9 +39,6 @@ module ContentBlockTools
   #    content_block_reference.embed_code #=> "{{embed:content_block_contact:2b92cade-549c-4449-9796-e7a3957f3a86/field_name}}"
   #  @return [String]
   class ContentBlock
-    include ActionView::Helpers::TagHelper
-    class UnknownComponentError < StandardError; end
-
     CONTENT_BLOCK_PREFIX = "content_block_".freeze
 
     attr_reader :content_id, :title, :embed_code
@@ -86,22 +83,12 @@ module ContentBlockTools
       @embed_code = embed_code
     end
 
-    # Calls the appropriate presenter class to return a HTML representation of a content
-    # block. Defaults to {Presenters::BasePresenter}
+    # Renders the content block to HTML using the appropriate component or presenter
     #
-    # @return [string] A HTML representation of the content block
+    # @return [String] A HTML representation of the content block
+    # @see Renderer
     def render
-      content_tag(
-        base_tag,
-        content,
-        class: %W[content-block content-block--#{document_type}],
-        data: {
-          content_block: "",
-          document_type: document_type,
-          content_id: content_id,
-          embed_code: embed_code,
-        },
-      )
+      Renderer.new(self).render
     end
 
     def details
@@ -110,60 +97,6 @@ module ContentBlockTools
 
     def document_type
       @document_type.delete_prefix(CONTENT_BLOCK_PREFIX)
-    end
-
-  private
-
-    def base_tag
-      rendering_block? ? :div : :span
-    end
-
-    def content
-      field_names.present? ? field_or_block_content : component.new(content_block: self).render
-    rescue UnknownComponentError
-      title
-    end
-
-    def field_or_block_content
-      content = details.dig(*field_names)
-
-      case content
-      when String
-        field_presenter(field_names.last).new(content).render
-      when Hash
-        if embedded_object_in_one_to_one_relationship?
-          field_presenter(field_names.last).new(content).render
-        else
-          component.new(content_block: self, block_type: field_names.first, block_name: field_names.last).render
-        end
-      else
-        ContentBlockTools.logger.warn("Content not found for content block #{content_id} and fields #{field_names}")
-        embed_code
-      end
-    end
-
-    def embedded_object_in_one_to_one_relationship?
-      field_names.one?
-    end
-
-    def rendering_block?
-      !field_names.present? || details.dig(*field_names).is_a?(Hash)
-    end
-
-    def component
-      "ContentBlockTools::#{document_type.camelize}Component".constantize
-    rescue NameError
-      raise UnknownComponentError
-    end
-
-    def field_presenter(field)
-      "ContentBlockTools::Presenters::FieldPresenters::#{document_type.camelize}::#{field.to_s.camelize}Presenter".constantize
-    rescue NameError
-      ContentBlockTools::Presenters::FieldPresenters::BasePresenter
-    end
-
-    def field_names
-      @field_names ||= EmbedCode.new(embed_code).field_names
     end
   end
 end

--- a/lib/content_block_tools/content_block_reference.rb
+++ b/lib/content_block_tools/content_block_reference.rb
@@ -43,7 +43,7 @@ module ContentBlockTools
     # The regex to find optional field names after the UUID, begins with '/'
     FIELD_REGEX = /(?<fields>\/[a-z0-9_\-–—\/]*)?/
     # The regex used when scanning a document using {ContentBlockTools::ContentBlockReference.find_all_in_document}
-    EMBED_REGEX = /({{embed:(#{SUPPORTED_DOCUMENT_TYPES.join('|')}):(#{UUID_REGEX}|#{CONTENT_ID_ALIAS_REGEX})#{FIELD_REGEX}}})/
+    EMBED_REGEX = /(?<embed_code>{{embed:(?<document_type>#{SUPPORTED_DOCUMENT_TYPES.join('|')}):(?<identifier>#{UUID_REGEX}|#{CONTENT_ID_ALIAS_REGEX})#{FIELD_REGEX}}})/
 
     # Returns if the identifier is an alias
     #
@@ -73,8 +73,8 @@ module ContentBlockTools
       #
       # @return [Array<ContentBlockReference>] An array of content block references
       def find_all_in_document(document)
-        document.scan(EMBED_REGEX).map do |match_data|
-          ContentBlockReference.from_match_data(match_data)
+        document.to_enum(:scan, EMBED_REGEX).map do
+          ContentBlockReference.from_match_data(Regexp.last_match)
         end
       end
 
@@ -97,7 +97,7 @@ module ContentBlockTools
         match_data = embed_code.match(/^#{EMBED_REGEX}$/)
         raise InvalidEmbedCodeError unless match_data
 
-        ContentBlockReference.from_match_data(match_data.captures)
+        ContentBlockReference.from_match_data(match_data)
       end
 
       # Converts match data from a regex scan into a ContentBlockReference object
@@ -107,8 +107,8 @@ module ContentBlockTools
       # by replacing en/em dashes with double/triple dashes (which can occur due to Kramdown's
       # markdown parsing) before creating the object.
       #
-      # @param match_data [MatchData, Array] the match data from scanning with {EMBED_REGEX}
-      #   Expected to contain: [full_match, document_type, identifier, field]
+      # @param match_data [MatchData] the match data from scanning with {EMBED_REGEX}
+      #   Expected named captures: embed_code, document_type, identifier, fields
       # @example Creating from match data
       #   match_data = "{{embed:content_block_pension:2b92cade-549c-4449-9796-e7a3957f3a86}}".match(EMBED_REGEX)
       #   ContentBlockReference.from_match_data(match_data)
@@ -121,7 +121,11 @@ module ContentBlockTools
       def from_match_data(match_data)
         match = prepare_match(match_data)
         ContentBlockTools.logger.info("Found Content Block Reference: #{match}")
-        ContentBlockReference.new(document_type: match[1], identifier: match[2], embed_code: match[0])
+        ContentBlockReference.new(
+          document_type: match[:document_type],
+          identifier: match[:identifier],
+          embed_code: match[:embed_code],
+        )
       end
 
     private
@@ -130,12 +134,12 @@ module ContentBlockTools
       # because Kramdown (the markdown parser that Govspeak is based on) replaces double dashes with en dashes and
       # triple dashes with em dashes
       def prepare_match(match)
-        [
-          match[0],
-          match[1],
-          replace_dashes(match[2]),
-          match[3],
-        ]
+        {
+          embed_code: match[:embed_code],
+          document_type: match[:document_type],
+          identifier: replace_dashes(match[:identifier]),
+          fields: match[:fields],
+        }
       end
 
       def replace_dashes(value)

--- a/lib/content_block_tools/content_block_reference.rb
+++ b/lib/content_block_tools/content_block_reference.rb
@@ -41,7 +41,7 @@ module ContentBlockTools
     # The regex used to find content ID aliases
     CONTENT_ID_ALIAS_REGEX = /[a-z0-9\-–—]+/
     # The regex to find optional field names after the UUID, begins with '/'
-    FIELD_REGEX = /(\/[a-z0-9_\-–—\/]*)?/
+    FIELD_REGEX = /(?<fields>\/[a-z0-9_\-–—\/]*)?/
     # The regex used when scanning a document using {ContentBlockTools::ContentBlockReference.find_all_in_document}
     EMBED_REGEX = /({{embed:(#{SUPPORTED_DOCUMENT_TYPES.join('|')}):(#{UUID_REGEX}|#{CONTENT_ID_ALIAS_REGEX})#{FIELD_REGEX}}})/
 

--- a/lib/content_block_tools/embed_code.rb
+++ b/lib/content_block_tools/embed_code.rb
@@ -37,7 +37,7 @@ module ContentBlockTools
       match = ContentBlockReference::EMBED_REGEX.match(embed_code_string)
       return [] unless match
 
-      all_fields = match[4]&.reverse&.chomp("/")&.reverse
+      all_fields = match[:fields]&.reverse&.chomp("/")&.reverse
       return [] if all_fields.nil?
 
       all_fields.split("/").map { |item| convert_field_item(item) }

--- a/lib/content_block_tools/embed_code.rb
+++ b/lib/content_block_tools/embed_code.rb
@@ -1,0 +1,54 @@
+module ContentBlockTools
+  # Parses and represents an embed code string
+  #
+  # An embed code identifies a content block and optionally specifies which
+  # fields to render. The format is:
+  #   {{embed:block_type:identifier}}
+  #   {{embed:block_type:identifier/field1/nested_field2}}
+  #
+  # @example Basic embed code
+  #   embed_code = EmbedCode.new("{{embed:content_block_contact:main-office}}")
+  #   embed_code.field_names #=> []
+  #
+  # @example Embed code with field path
+  #   embed_code = EmbedCode.new("{{embed:content_block_contact:main-office/email_addresses/main}}")
+  #   embed_code.field_names #=> [:email_addresses, :main]
+  #
+  class EmbedCode
+    def initialize(embed_code_string)
+      @embed_code_string = embed_code_string
+    end
+
+    # Returns the field names extracted from the embed code path
+    #
+    # Field names are the path components after the identifier, converted to symbols
+    # or integers as appropriate.
+    #
+    # @return [Array<Symbol, Integer>] The field names, or [] if no path
+    def field_names
+      @field_names ||= parse_field_names
+    end
+
+  private
+
+    attr_reader :embed_code_string
+
+    def parse_field_names
+      match = ContentBlockReference::EMBED_REGEX.match(embed_code_string)
+      return [] unless match
+
+      all_fields = match[4]&.reverse&.chomp("/")&.reverse
+      return [] if all_fields.nil?
+
+      all_fields.split("/").map { |item| convert_field_item(item) }
+    end
+
+    def convert_field_item(item)
+      numeric?(item) ? item.to_i : item.to_sym
+    end
+
+    def numeric?(item)
+      Float(item, exception: false)
+    end
+  end
+end

--- a/lib/content_block_tools/renderer.rb
+++ b/lib/content_block_tools/renderer.rb
@@ -1,0 +1,110 @@
+module ContentBlockTools
+  # Renders a ContentBlock to HTML
+  #
+  # This class encapsulates the logic for rendering a content block,
+  # including determining the appropriate component or presenter to use
+  # and wrapping the result in the standard content block markup.
+  #
+  # @example
+  #   content_block = ContentBlock.new(...)
+  #   html = Renderer.new(content_block).render
+  #
+  class Renderer
+    include ActionView::Helpers::TagHelper
+
+    class UnknownComponentError < StandardError; end
+
+    def initialize(content_block)
+      @content_block = content_block
+    end
+
+    # Renders the content block to HTML
+    #
+    # @return [String] HTML representation of the content block
+    def render
+      content_tag(
+        base_tag,
+        content,
+        class: %W[content-block content-block--#{content_block.document_type}],
+        data: {
+          content_block: "",
+          document_type: content_block.document_type,
+          content_id: content_block.content_id,
+          embed_code: content_block.embed_code,
+        },
+      )
+    end
+
+  private
+
+    attr_reader :content_block
+
+    def base_tag
+      rendering_block? ? :div : :span
+    end
+
+    def content
+      field_names.present? ? field_or_block_content : component.new(content_block:).render
+    rescue UnknownComponentError
+      content_block.title
+    end
+
+    def field_or_block_content
+      field_content = content_block.details.dig(*field_names)
+
+      case field_content
+      when String
+        field_presenter(field_names.last).new(field_content).render
+      when Hash
+        render_hash_content(field_content)
+      else
+        log_content_not_found
+        content_block.embed_code
+      end
+    end
+
+    def render_hash_content(field_content)
+      if embedded_object_in_one_to_one_relationship?
+        field_presenter(field_names.last).new(field_content).render
+      else
+        component.new(
+          content_block:,
+          block_type: field_names.first,
+          block_name: field_names.last,
+        ).render
+      end
+    end
+
+    def log_content_not_found
+      ContentBlockTools.logger.warn(
+        "Content not found for content block #{content_block.content_id} and fields #{field_names}",
+      )
+    end
+
+    def embedded_object_in_one_to_one_relationship?
+      field_names.one?
+    end
+
+    def rendering_block?
+      !field_names.present? || content_block.details.dig(*field_names).is_a?(Hash)
+    end
+
+    def component
+      "ContentBlockTools::#{content_block.document_type.camelize}Component".constantize
+    rescue NameError
+      raise UnknownComponentError
+    end
+
+    def field_presenter(field)
+      presenter_class_name = "ContentBlockTools::Presenters::FieldPresenters::" \
+                             "#{content_block.document_type.camelize}::#{field.to_s.camelize}Presenter"
+      presenter_class_name.constantize
+    rescue NameError
+      ContentBlockTools::Presenters::FieldPresenters::BasePresenter
+    end
+
+    def field_names
+      @field_names ||= EmbedCode.new(content_block.embed_code).field_names
+    end
+  end
+end

--- a/spec/content_block_tools/content_block_reference_spec.rb
+++ b/spec/content_block_tools/content_block_reference_spec.rb
@@ -79,8 +79,8 @@ RSpec.describe ContentBlockTools::ContentBlockReference do
 
       describe "#content_references" do
         it "returns all references" do
-          expect(ContentBlockTools.logger).to receive(:info).with("Found Content Block Reference: [\"{{embed:contact:#{contact_uuid}}}\", \"contact\", \"#{contact_uuid}\", nil]")
-          expect(ContentBlockTools.logger).to receive(:info).with("Found Content Block Reference: [\"{{embed:content_block_pension:#{content_block_pension_uuid}}}\", \"content_block_pension\", \"#{content_block_pension_uuid}\", nil]")
+          expect(ContentBlockTools.logger).to receive(:info).with("Found Content Block Reference: {:embed_code=>\"{{embed:contact:#{contact_uuid}}}\", :document_type=>\"contact\", :identifier=>\"#{contact_uuid}\", :fields=>nil}")
+          expect(ContentBlockTools.logger).to receive(:info).with("Found Content Block Reference: {:embed_code=>\"{{embed:content_block_pension:#{content_block_pension_uuid}}}\", :document_type=>\"content_block_pension\", :identifier=>\"#{content_block_pension_uuid}\", :fields=>nil}")
 
           expect(result.count).to eq(2)
 
@@ -155,8 +155,8 @@ RSpec.describe ContentBlockTools::ContentBlockReference do
 
       describe "#content_references" do
         it "returns all references" do
-          expect(ContentBlockTools.logger).to receive(:info).with("Found Content Block Reference: [\"{{embed:contact:#{contact_alias}}}\", \"contact\", \"#{contact_alias}\", nil]")
-          expect(ContentBlockTools.logger).to receive(:info).with("Found Content Block Reference: [\"{{embed:content_block_pension:#{content_block_pension_alias}}}\", \"content_block_pension\", \"#{content_block_pension_alias}\", nil]")
+          expect(ContentBlockTools.logger).to receive(:info).with("Found Content Block Reference: {:embed_code=>\"{{embed:contact:#{contact_alias}}}\", :document_type=>\"contact\", :identifier=>\"#{contact_alias}\", :fields=>nil}")
+          expect(ContentBlockTools.logger).to receive(:info).with("Found Content Block Reference: {:embed_code=>\"{{embed:content_block_pension:#{content_block_pension_alias}}}\", :document_type=>\"content_block_pension\", :identifier=>\"#{content_block_pension_alias}\", :fields=>nil}")
 
           expect(result.count).to eq(2)
 

--- a/spec/content_block_tools/embed_code_spec.rb
+++ b/spec/content_block_tools/embed_code_spec.rb
@@ -1,0 +1,43 @@
+RSpec.describe ContentBlockTools::EmbedCode do
+  describe "#field_names" do
+    context "when embed code has no field path" do
+      let(:embed_code) { "{{embed:content_block_contact:main-office}}" }
+
+      it "returns an empty array" do
+        expect(described_class.new(embed_code).field_names).to eq([])
+      end
+    end
+
+    context "when embed code has a single field" do
+      let(:embed_code) { "{{embed:content_block_contact:main-office/email}}" }
+
+      it "returns the field as a symbol" do
+        expect(described_class.new(embed_code).field_names).to eq([:email])
+      end
+    end
+
+    context "when embed code has multiple fields" do
+      let(:embed_code) { "{{embed:content_block_contact:main-office/email_addresses/main}}" }
+
+      it "returns all fields as symbols" do
+        expect(described_class.new(embed_code).field_names).to eq(%i[email_addresses main])
+      end
+    end
+
+    context "when embed code has numeric segments" do
+      let(:embed_code) { "{{embed:content_block_contact:main-office/email_addresses/0/email}}" }
+
+      it "converts numeric segments to integers" do
+        expect(described_class.new(embed_code).field_names).to eq([:email_addresses, 0, :email])
+      end
+    end
+
+    context "when embed code is invalid" do
+      let(:embed_code) { "invalid" }
+
+      it "returns an empty list" do
+        expect(described_class.new(embed_code).field_names).to be_empty
+      end
+    end
+  end
+end

--- a/spec/content_block_tools/renderer_spec.rb
+++ b/spec/content_block_tools/renderer_spec.rb
@@ -1,0 +1,172 @@
+RSpec.describe ContentBlockTools::Renderer do
+  let(:content_id) { SecureRandom.uuid }
+  let(:title) { "Test Block" }
+  let(:embed_code) { "{{embed:content_block_time_period:#{content_id}}}" }
+
+  let(:content_block) do
+    ContentBlockTools::ContentBlock.new(
+      content_id:,
+      title:,
+      document_type: "content_block_time_period",
+      details: {
+        date_range: {
+          start: "2024-04-06",
+          end: "2025-04-05",
+        },
+      },
+      embed_code:,
+    )
+  end
+
+  describe "#render" do
+    subject(:rendered) { described_class.new(content_block).render }
+
+    it "wraps content in a div with content-block classes" do
+      expect(rendered).to have_tag("div.content-block.content-block--time_period")
+    end
+
+    it "includes data attributes" do
+      expect(rendered).to have_tag(
+        "div",
+        with: {
+          "data-content-block" => "",
+          "data-document-type" => "time_period",
+          "data-content-id" => content_id,
+          "data-embed-code" => embed_code,
+        },
+      )
+    end
+
+    context "when rendering a component" do
+      it "renders using the component" do
+        expect(rendered).to have_tag("p.govuk-body", seen: "6 April 2024 to 5 April 2025")
+      end
+    end
+
+    context "when no component exists for the document type" do
+      let(:content_block) do
+        ContentBlockTools::ContentBlock.new(
+          content_id:,
+          title:,
+          document_type: "content_block_unknown",
+          details: {},
+          embed_code: "{{embed:content_block_unknown:#{content_id}}}",
+        )
+      end
+
+      it "falls back to displaying the title" do
+        expect(rendered).to have_tag("div", seen: title)
+      end
+    end
+
+    context "when rendering a string field" do
+      let(:embed_code) { "{{embed:content_block_contact:#{content_id}/email_addresses/main/email_address}}" }
+
+      let(:content_block) do
+        ContentBlockTools::ContentBlock.new(
+          content_id:,
+          title:,
+          document_type: "content_block_contact",
+          details: {
+            email_addresses: {
+              main: {
+                title: "Email",
+                email_address: "test@example.gov.uk",
+              },
+            },
+          },
+          embed_code:,
+        )
+      end
+
+      it "renders using a span tag" do
+        expect(rendered).to have_tag("span.content-block.content-block--contact")
+      end
+
+      it "renders the string field value" do
+        expect(rendered).to include("test@example.gov.uk")
+      end
+    end
+
+    context "when rendering a hash field in a one-to-one relationship" do
+      let(:embed_code) { "{{embed:content_block_time_period:#{content_id}/date_range}}" }
+
+      let(:content_block) do
+        ContentBlockTools::ContentBlock.new(
+          content_id:,
+          title:,
+          document_type: "content_block_time_period",
+          details: {
+            date_range: {
+              start: "2024-04-06",
+              end: "2025-04-05",
+            },
+          },
+          embed_code:,
+        )
+      end
+
+      it "renders using a div tag (block content)" do
+        expect(rendered).to have_tag("div.content-block.content-block--time_period")
+      end
+
+      it "uses the field presenter for the hash" do
+        expect(rendered).to include("6 April 2024")
+        expect(rendered).to include("5 April 2025")
+      end
+    end
+
+    context "when rendering a hash field with block_type and block_name" do
+      let(:embed_code) { "{{embed:content_block_contact:#{content_id}/email_addresses/main}}" }
+
+      let(:content_block) do
+        ContentBlockTools::ContentBlock.new(
+          content_id:,
+          title:,
+          document_type: "content_block_contact",
+          details: {
+            email_addresses: {
+              main: {
+                title: "Main Email",
+                email_address: "main@example.gov.uk",
+              },
+            },
+          },
+          embed_code:,
+        )
+      end
+
+      it "renders using the component with block_type and block_name" do
+        expect(rendered).to have_tag("div.content-block.content-block--contact")
+      end
+    end
+
+    context "when field content is not found" do
+      before { allow(ContentBlockTools.logger).to receive(:warn) }
+
+      let(:embed_code) { "{{embed:content_block_contact:#{content_id}/nonexistent/field}}" }
+
+      let(:content_block) do
+        ContentBlockTools::ContentBlock.new(
+          content_id:,
+          title:,
+          document_type: "content_block_contact",
+          details: {},
+          embed_code:,
+        )
+      end
+
+      it "logs a warning" do
+        rendered
+
+        expect(ContentBlockTools.logger).to have_received(:warn).with(
+          "Content not found for content block #{content_id} and fields [:nonexistent, :field]",
+        )
+      end
+
+      it "returns the embed code" do
+        expect(rendered).to include(embed_code)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR is the first of three new PRs resulting from the experimental https://github.com/alphagov/govuk_content_block_tools/pull/141 work:

### 1. This PR: Initial refactoring which is of immediate value and also prepares for the following feature

This PR, which we plan to merge right away, once reviewed

### 2. Refactoring 2: [PR 150](https://github.com/alphagov/govuk_content_block_tools/pull/150) replacing field_names with InternalContentPath

https://github.com/alphagov/govuk_content_block_tools/pull/150 which can also be merged once reviewed as it brings a immediate improvement in clarity.

### 3. [Feature PR 147](https://github.com/alphagov/govuk_content_block_tools/pull/147) adding support for "format" specifier in embed code

[PR 147](https://github.com/alphagov/govuk_content_block_tools/pull/147) built on this refactoring. To be merged once reviewed and discussed. It does not introduce any breaking changes so will be safe to merge once agreed and discussed.