### PR TITLE
CM-865: Add format specifier

### DIFF
--- a/app/components/content_block_tools/time_period/long_form_component.html.erb
+++ b/app/components/content_block_tools/time_period/long_form_component.html.erb
@@ -1,0 +1,3 @@
+<p class="govuk-body">
+  <%= formatted_date(start_date) %> to <%= formatted_date(end_date) %>
+</p>

--- a/app/components/content_block_tools/time_period/long_form_component.rb
+++ b/app/components/content_block_tools/time_period/long_form_component.rb
@@ -1,0 +1,24 @@
+module ContentBlockTools
+  module TimePeriod
+    class LongFormComponent < ContentBlockTools::BaseComponent
+      def initialize(start_date:, end_date:)
+        @start_date = start_date
+        @end_date = end_date
+      end
+
+      def render
+        return "" unless start_date && end_date
+
+        render_in(view_context)
+      end
+
+    private
+
+      attr_reader :start_date, :end_date
+
+      def formatted_date(date)
+        Presenters::FieldPresenters::TimePeriod::DatePresenter.new(date).render
+      end
+    end
+  end
+end

--- a/app/components/content_block_tools/time_period/months_and_years_long_component.html.erb
+++ b/app/components/content_block_tools/time_period/months_and_years_long_component.html.erb
@@ -1,0 +1,3 @@
+<p class="govuk-body">
+  <%= formatted_date(start_date) %> to <%= formatted_date(end_date) %>
+</p>

--- a/app/components/content_block_tools/time_period/months_and_years_long_component.rb
+++ b/app/components/content_block_tools/time_period/months_and_years_long_component.rb
@@ -1,0 +1,24 @@
+module ContentBlockTools
+  module TimePeriod
+    class MonthsAndYearsLongComponent < ContentBlockTools::BaseComponent
+      def initialize(start_date:, end_date:)
+        @start_date = start_date
+        @end_date = end_date
+      end
+
+      def render
+        return "" unless start_date && end_date
+
+        render_in(view_context)
+      end
+
+    private
+
+      attr_reader :start_date, :end_date
+
+      def formatted_date(date)
+        date.strftime("%B %Y")
+      end
+    end
+  end
+end

--- a/app/components/content_block_tools/time_period/start_day_and_month_component.html.erb
+++ b/app/components/content_block_tools/time_period/start_day_and_month_component.html.erb
@@ -1,0 +1,3 @@
+<p class="govuk-body">
+  <%= formatted_date %>
+</p>

--- a/app/components/content_block_tools/time_period/start_day_and_month_component.rb
+++ b/app/components/content_block_tools/time_period/start_day_and_month_component.rb
@@ -1,0 +1,23 @@
+module ContentBlockTools
+  module TimePeriod
+    class StartDayAndMonthComponent < ContentBlockTools::BaseComponent
+      def initialize(start_date:)
+        @start_date = start_date
+      end
+
+      def render
+        return "" unless start_date
+
+        render_in(view_context)
+      end
+
+    private
+
+      attr_reader :start_date
+
+      def formatted_date
+        start_date.strftime("%e %B").strip
+      end
+    end
+  end
+end

--- a/app/components/content_block_tools/time_period/start_month_as_word_component.html.erb
+++ b/app/components/content_block_tools/time_period/start_month_as_word_component.html.erb
@@ -1,0 +1,3 @@
+<p class="govuk-body">
+  <%= formatted_date %>
+</p>

--- a/app/components/content_block_tools/time_period/start_month_as_word_component.rb
+++ b/app/components/content_block_tools/time_period/start_month_as_word_component.rb
@@ -1,0 +1,23 @@
+module ContentBlockTools
+  module TimePeriod
+    class StartMonthAsWordComponent < ContentBlockTools::BaseComponent
+      def initialize(start_date:)
+        @start_date = start_date
+      end
+
+      def render
+        return "" unless start_date
+
+        render_in(view_context)
+      end
+
+    private
+
+      attr_reader :start_date
+
+      def formatted_date
+        start_date.strftime("%B")
+      end
+    end
+  end
+end

--- a/app/components/content_block_tools/time_period/years_component.html.erb
+++ b/app/components/content_block_tools/time_period/years_component.html.erb
@@ -1,0 +1,3 @@
+<p class="govuk-body">
+  <%= formatted_years %>
+</p>

--- a/app/components/content_block_tools/time_period/years_component.rb
+++ b/app/components/content_block_tools/time_period/years_component.rb
@@ -1,0 +1,24 @@
+module ContentBlockTools
+  module TimePeriod
+    class YearsComponent < ContentBlockTools::BaseComponent
+      def initialize(start_date:, end_date:)
+        @start_date = start_date
+        @end_date = end_date
+      end
+
+      def render
+        return "" unless start_date && end_date
+
+        render_in(view_context)
+      end
+
+    private
+
+      attr_reader :start_date, :end_date
+
+      def formatted_years
+        "#{start_date.year}-#{end_date.year}"
+      end
+    end
+  end
+end

--- a/app/components/content_block_tools/time_period/years_short_component.html.erb
+++ b/app/components/content_block_tools/time_period/years_short_component.html.erb
@@ -1,0 +1,3 @@
+<p class="govuk-body">
+  <%= formatted_years %>
+</p>

--- a/app/components/content_block_tools/time_period/years_short_component.rb
+++ b/app/components/content_block_tools/time_period/years_short_component.rb
@@ -1,0 +1,24 @@
+module ContentBlockTools
+  module TimePeriod
+    class YearsShortComponent < ContentBlockTools::BaseComponent
+      def initialize(start_date:, end_date:)
+        @start_date = start_date
+        @end_date = end_date
+      end
+
+      def render
+        return "" unless start_date && end_date
+
+        render_in(view_context)
+      end
+
+    private
+
+      attr_reader :start_date, :end_date
+
+      def formatted_years
+        "#{start_date.year}-#{end_date.strftime('%y')}"
+      end
+    end
+  end
+end

--- a/app/components/content_block_tools/time_period_component.html.erb
+++ b/app/components/content_block_tools/time_period_component.html.erb
@@ -1,8 +1,0 @@
-<% if start_date.present? && end_date.present?  %>
-  <p class="govuk-body">
-    <%= start_date %>
-    to
-    <%= end_date %>
-  </p>
-<% end %>
-

--- a/app/components/content_block_tools/time_period_component.rb
+++ b/app/components/content_block_tools/time_period_component.rb
@@ -17,20 +17,7 @@ module ContentBlockTools
     end
 
     def render
-      case defaulted_format
-      when "long_form"
-        render_long_form
-      when "months_and_years_long"
-        render_months_and_years_long
-      when "start_day_and_month"
-        render_start_day_and_month
-      when "start_month_as_word"
-        render_start_month_as_word
-      when "years"
-        render_years
-      when "years_short"
-        render_years_short
-      end
+      format_component.render
     end
 
   private
@@ -38,6 +25,23 @@ module ContentBlockTools
     attr_reader :content_block, :normalised_date_range
 
     delegate :format, to: :content_block
+
+    def format_component
+      case defaulted_format
+      when "long_form"
+        TimePeriod::LongFormComponent.new(start_date:, end_date:)
+      when "months_and_years_long"
+        TimePeriod::MonthsAndYearsLongComponent.new(start_date:, end_date:)
+      when "start_day_and_month"
+        TimePeriod::StartDayAndMonthComponent.new(start_date:)
+      when "start_month_as_word"
+        TimePeriod::StartMonthAsWordComponent.new(start_date:)
+      when "years"
+        TimePeriod::YearsComponent.new(start_date:, end_date:)
+      when "years_short"
+        TimePeriod::YearsShortComponent.new(start_date:, end_date:)
+      end
+    end
 
     def defaulted_format
       return "long_form" if format == Format::DEFAULT_FORMAT
@@ -61,69 +65,6 @@ module ContentBlockTools
 
     def end_date
       normalised_date_range.end_date
-    end
-
-    def render_long_form
-      return "" unless start_date && end_date
-
-      content_tag(:p, class: "govuk-body") do
-        "#{format_date(start_date, :full)} to #{format_date(end_date, :full)}"
-      end
-    end
-
-    def render_months_and_years_long
-      return "" unless start_date && end_date
-
-      content_tag(:p, class: "govuk-body") do
-        "#{format_date(start_date, :month_year)} to #{format_date(end_date, :month_year)}"
-      end
-    end
-
-    def render_start_day_and_month
-      return "" unless start_date
-
-      content_tag(:p, class: "govuk-body") do
-        format_date(start_date, :day_month)
-      end
-    end
-
-    def render_start_month_as_word
-      return "" unless start_date
-
-      content_tag(:p, class: "govuk-body") do
-        format_date(start_date, :month_only)
-      end
-    end
-
-    def render_years
-      return "" unless start_date && end_date
-
-      content_tag(:p, class: "govuk-body") do
-        "#{start_date.year}-#{end_date.year}"
-      end
-    end
-
-    def render_years_short
-      return "" unless start_date && end_date
-
-      content_tag(:p, class: "govuk-body") do
-        "#{start_date.year}-#{end_date.strftime('%y')}"
-      end
-    end
-
-    def format_date(date, style)
-      case style
-      when :full
-        Presenters::FieldPresenters::TimePeriod::DatePresenter.new(
-          date,
-        ).render
-      when :month_year
-        date.strftime("%B %Y")
-      when :day_month
-        date.strftime("%e %B").strip
-      when :month_only
-        date.strftime("%B")
-      end
     end
   end
 end

--- a/app/components/content_block_tools/time_period_component.rb
+++ b/app/components/content_block_tools/time_period_component.rb
@@ -1,32 +1,129 @@
 module ContentBlockTools
   class TimePeriodComponent < ContentBlockTools::BaseComponent
+    SUPPORTED_FORMATS = %w[
+      default
+      long_form
+      months_and_years_long
+      start_day_and_month
+      start_month_as_word
+      years
+      years_short
+    ].freeze
+
     def initialize(content_block:, _block_type: nil, _block_name: nil)
       @content_block = content_block
       @normalised_date_range = normalise_date_range
+      validate_format!
     end
 
-    def start_date
-      presented_date(normalised_date_range.start_date)
-    end
-
-    def end_date
-      presented_date(normalised_date_range.end_date)
+    def render
+      case defaulted_format
+      when "long_form"
+        render_long_form
+      when "months_and_years_long"
+        render_months_and_years_long
+      when "start_day_and_month"
+        render_start_day_and_month
+      when "start_month_as_word"
+        render_start_month_as_word
+      when "years"
+        render_years
+      when "years_short"
+        render_years_short
+      end
     end
 
   private
 
     attr_reader :content_block, :normalised_date_range
 
+    delegate :format, to: :content_block
+
+    def defaulted_format
+      return "long_form" if format == Format::DEFAULT_FORMAT
+
+      format
+    end
+
+    def validate_format!
+      return if SUPPORTED_FORMATS.include?(format)
+
+      raise InvalidFormatError, "Unknown format '#{format}' for time_period"
+    end
+
     def normalise_date_range
       NormalisedDateRange.new(content_block.details[:date_range])
     end
 
-    def presented_date(date)
-      return unless date.present?
+    def start_date
+      normalised_date_range.start_date
+    end
 
-      Presenters::FieldPresenters::TimePeriod::DatePresenter.new(
-        date,
-      ).render
+    def end_date
+      normalised_date_range.end_date
+    end
+
+    def render_long_form
+      return "" unless start_date && end_date
+
+      content_tag(:p, class: "govuk-body") do
+        "#{format_date(start_date, :full)} to #{format_date(end_date, :full)}"
+      end
+    end
+
+    def render_months_and_years_long
+      return "" unless start_date && end_date
+
+      content_tag(:p, class: "govuk-body") do
+        "#{format_date(start_date, :month_year)} to #{format_date(end_date, :month_year)}"
+      end
+    end
+
+    def render_start_day_and_month
+      return "" unless start_date
+
+      content_tag(:p, class: "govuk-body") do
+        format_date(start_date, :day_month)
+      end
+    end
+
+    def render_start_month_as_word
+      return "" unless start_date
+
+      content_tag(:p, class: "govuk-body") do
+        format_date(start_date, :month_only)
+      end
+    end
+
+    def render_years
+      return "" unless start_date && end_date
+
+      content_tag(:p, class: "govuk-body") do
+        "#{start_date.year}-#{end_date.year}"
+      end
+    end
+
+    def render_years_short
+      return "" unless start_date && end_date
+
+      content_tag(:p, class: "govuk-body") do
+        "#{start_date.year}-#{end_date.strftime('%y')}"
+      end
+    end
+
+    def format_date(date, style)
+      case style
+      when :full
+        Presenters::FieldPresenters::TimePeriod::DatePresenter.new(
+          date,
+        ).render
+      when :month_year
+        date.strftime("%B %Y")
+      when :day_month
+        date.strftime("%e %B").strip
+      when :month_only
+        date.strftime("%B")
+      end
     end
   end
 end

--- a/features/step_definitions/time_period_steps.rb
+++ b/features/step_definitions/time_period_steps.rb
@@ -1,3 +1,42 @@
+Given("a time period content block with the following date range:") do |table|
+  details = table.rows_hash
+  @content_block_details = {
+    date_range: {
+      start: details.fetch("start"),
+      end: details.fetch("end"),
+    },
+  }
+end
+
+When("asked to render with embed code {string}") do |embed_code|
+  @embed_code = embed_code
+  @content_block = ContentBlockTools::ContentBlock.new(
+    document_type: "content_block_time_period",
+    content_id: SecureRandom.uuid,
+    title: "Tax year",
+    details: @content_block_details,
+    embed_code:,
+  )
+
+  begin
+    @rendered = @content_block.render
+    @error = nil
+  rescue ContentBlockTools::InvalidFormatError => e
+    @error = e
+    @rendered = nil
+  end
+end
+
+Then("the rendered output should be {string}") do |expected_text|
+  expect(@error).to be_nil, "Expected no error but got: #{@error&.message}"
+  expect(@rendered).to include(expected_text)
+end
+
+Then("an InvalidFormatError should be raised with message {string}") do |expected_message|
+  expect(@error).to be_a(ContentBlockTools::InvalidFormatError)
+  expect(@error.message).to eq(expected_message)
+end
+
 Given("a time period content block exists") do
   @content_block = ContentBlockTools::ContentBlock.new(
     document_type: "content_block_time_period",

--- a/features/time_period_rendering.feature
+++ b/features/time_period_rendering.feature
@@ -3,7 +3,43 @@ Feature: Time period rendering
   As a content editor
   I want time period blocks to render with GDS style formatting
 
-  Scenario: Time period renders with default formatting
-    Given a time period content block exists
-    When I render the content block
-    Then I should see the time period displayed in the default long form
+  Background:
+    Given a time period content block with the following date range:
+      | start | 2025-04-06T00:00:00+01:00 |
+      | end   | 2026-04-05T23:59:00+01:00 |
+
+  Scenario: Render with default format when no format specified
+    When asked to render with embed code "{{embed:content_block_time_period:tax-year}}"
+    Then the rendered output should be "6 April 2025 to 5 April 2026"
+
+  Scenario: Render with explicit default format
+    When asked to render with embed code "{{embed:content_block_time_period:tax-year|default}}"
+    Then the rendered output should be "6 April 2025 to 5 April 2026"
+
+  Scenario: Render with explicit long_form format
+    When asked to render with embed code "{{embed:content_block_time_period:tax-year|long_form}}"
+    Then the rendered output should be "6 April 2025 to 5 April 2026"
+
+  Scenario: Render with months_and_years_long format
+    When asked to render with embed code "{{embed:content_block_time_period:tax-year|months_and_years_long}}"
+    Then the rendered output should be "April 2025 to April 2026"
+
+  Scenario: Render with start_day_and_month format
+    When asked to render with embed code "{{embed:content_block_time_period:tax-year|start_day_and_month}}"
+    Then the rendered output should be "6 April"
+
+  Scenario: Render with start_month_as_word format
+    When asked to render with embed code "{{embed:content_block_time_period:tax-year|start_month_as_word}}"
+    Then the rendered output should be "April"
+
+  Scenario: Render with years format
+    When asked to render with embed code "{{embed:content_block_time_period:tax-year|years}}"
+    Then the rendered output should be "2025-2026"
+
+  Scenario: Render with years_short format
+    When asked to render with embed code "{{embed:content_block_time_period:tax-year|years_short}}"
+    Then the rendered output should be "2025-26"
+
+  Scenario: Raise error for invalid format
+    When asked to render with embed code "{{embed:content_block_time_period:tax-year|unknown_format}}"
+    Then an InvalidFormatError should be raised with message "Unknown format 'unknown_format' for time_period"

--- a/features/time_period_rendering.feature
+++ b/features/time_period_rendering.feature
@@ -13,33 +13,33 @@ Feature: Time period rendering
     Then the rendered output should be "6 April 2025 to 5 April 2026"
 
   Scenario: Render with explicit default format
-    When asked to render with embed code "{{embed:content_block_time_period:tax-year|default}}"
+    When asked to render with embed code "{{embed:content_block_time_period:tax-year#default}}"
     Then the rendered output should be "6 April 2025 to 5 April 2026"
 
   Scenario: Render with explicit long_form format
-    When asked to render with embed code "{{embed:content_block_time_period:tax-year|long_form}}"
+    When asked to render with embed code "{{embed:content_block_time_period:tax-year#long_form}}"
     Then the rendered output should be "6 April 2025 to 5 April 2026"
 
   Scenario: Render with months_and_years_long format
-    When asked to render with embed code "{{embed:content_block_time_period:tax-year|months_and_years_long}}"
+    When asked to render with embed code "{{embed:content_block_time_period:tax-year#months_and_years_long}}"
     Then the rendered output should be "April 2025 to April 2026"
 
   Scenario: Render with start_day_and_month format
-    When asked to render with embed code "{{embed:content_block_time_period:tax-year|start_day_and_month}}"
+    When asked to render with embed code "{{embed:content_block_time_period:tax-year#start_day_and_month}}"
     Then the rendered output should be "6 April"
 
   Scenario: Render with start_month_as_word format
-    When asked to render with embed code "{{embed:content_block_time_period:tax-year|start_month_as_word}}"
+    When asked to render with embed code "{{embed:content_block_time_period:tax-year#start_month_as_word}}"
     Then the rendered output should be "April"
 
   Scenario: Render with years format
-    When asked to render with embed code "{{embed:content_block_time_period:tax-year|years}}"
+    When asked to render with embed code "{{embed:content_block_time_period:tax-year#years}}"
     Then the rendered output should be "2025-2026"
 
   Scenario: Render with years_short format
-    When asked to render with embed code "{{embed:content_block_time_period:tax-year|years_short}}"
+    When asked to render with embed code "{{embed:content_block_time_period:tax-year#years_short}}"
     Then the rendered output should be "2025-26"
 
   Scenario: Raise error for invalid format
-    When asked to render with embed code "{{embed:content_block_time_period:tax-year|unknown_format}}"
+    When asked to render with embed code "{{embed:content_block_time_period:tax-year#unknown_format}}"
     Then an InvalidFormatError should be raised with message "Unknown format 'unknown_format' for time_period"

--- a/lib/content_block_tools.rb
+++ b/lib/content_block_tools.rb
@@ -19,6 +19,7 @@ require "content_block_tools/presenters/field_presenters/time_period/end_present
 require "content_block_tools/content_block"
 require "content_block_tools/content_block_reference"
 require "content_block_tools/embed_code"
+require "content_block_tools/format"
 require "content_block_tools/internal_content_path"
 require "content_block_tools/normalised_date_range"
 require "content_block_tools/renderer"

--- a/lib/content_block_tools.rb
+++ b/lib/content_block_tools.rb
@@ -37,6 +37,7 @@ module ContentBlockTools
 
   module Components
     module Contacts; end
+    module TimePeriod; end
   end
 
   class << self

--- a/lib/content_block_tools.rb
+++ b/lib/content_block_tools.rb
@@ -31,6 +31,7 @@ require "content_block_tools/version"
 module ContentBlockTools
   class Error < StandardError; end
   class InvalidEmbedCodeError < StandardError; end
+  class InvalidFormatError < StandardError; end
 
   module Presenters; end
 

--- a/lib/content_block_tools/content_block.rb
+++ b/lib/content_block_tools/content_block.rb
@@ -38,6 +38,12 @@ module ContentBlockTools
   #    content_block_reference.embed_code #=> "{{embed:content_block_pension:2b92cade-549c-4449-9796-e7a3957f3a86}}"
   #    content_block_reference.embed_code #=> "{{embed:content_block_contact:2b92cade-549c-4449-9796-e7a3957f3a86/field_name}}"
   #  @return [String]
+  #
+  # @!attribute [r] format
+  #  The format specifier from the embed code, used to control rendering output
+  #  @example
+  #    content_block.format #=> "years_short"
+  #  @return [String]
   class ContentBlock
     CONTENT_BLOCK_PREFIX = "content_block_".freeze
 
@@ -97,6 +103,10 @@ module ContentBlockTools
 
     def document_type
       @document_type.delete_prefix(CONTENT_BLOCK_PREFIX)
+    end
+
+    def format
+      EmbedCode.new(embed_code).format
     end
   end
 end

--- a/lib/content_block_tools/embed_code.rb
+++ b/lib/content_block_tools/embed_code.rb
@@ -5,6 +5,8 @@ module ContentBlockTools
   # fields to render. The format is:
   #   {{embed:block_type:identifier}}
   #   {{embed:block_type:identifier/field1/nested_field2}}
+  #   {{embed:block_type:identifier|format}}
+  #   {{embed:block_type:identifier/field1|format}}
   #
   # @example Basic embed code
   #   embed_code = EmbedCode.new("{{embed:content_block_contact:main-office}}")
@@ -14,7 +16,13 @@ module ContentBlockTools
   #   embed_code = EmbedCode.new("{{embed:content_block_contact:main-office/email_addresses/main}}")
   #   embed_code.internal_content_path.path #=> [:email_addresses, :main]
   #
+  # @example Embed code with format
+  #   embed_code = EmbedCode.new("{{embed:content_block_time_period:tax-year|years_short}}")
+  #   embed_code.format #=> "years_short"
+  #
   class EmbedCode
+    FORMAT_REGEX = /\|(?<format>[^}]+)}}$/
+
     def initialize(embed_code_string)
       @embed_code_string = embed_code_string
     end
@@ -24,6 +32,13 @@ module ContentBlockTools
     # @return [InternalContentPath] The path to internal content
     def internal_content_path
       @internal_content_path ||= InternalContentPath.new(parse_path_segments)
+    end
+
+    # Returns the format specifier from the embed code
+    #
+    # @return [String] The format name, or Format::DEFAULT_FORMAT if none specified
+    def format
+      @format ||= parse_format
     end
 
   private
@@ -46,6 +61,13 @@ module ContentBlockTools
 
     def convert_segment(item)
       numeric?(item) ? item.to_i : item.to_sym
+    end
+
+    def parse_format
+      match = FORMAT_REGEX.match(embed_code_string)
+      return Format::DEFAULT_FORMAT unless match
+
+      match[:format]
     end
 
     def numeric?(item)

--- a/lib/content_block_tools/embed_code.rb
+++ b/lib/content_block_tools/embed_code.rb
@@ -17,11 +17,11 @@ module ContentBlockTools
   #   embed_code.internal_content_path.path #=> [:email_addresses, :main]
   #
   # @example Embed code with format
-  #   embed_code = EmbedCode.new("{{embed:content_block_time_period:tax-year|years_short}}")
+  #   embed_code = EmbedCode.new("{{embed:content_block_time_period:tax-year#years_short}}")
   #   embed_code.format #=> "years_short"
   #
   class EmbedCode
-    FORMAT_REGEX = /\|(?<format>[^}|]+)}}$/
+    FORMAT_REGEX = /\#(?<format>[^}#]+)}}$/
 
     def initialize(embed_code_string)
       @embed_code_string = embed_code_string

--- a/lib/content_block_tools/embed_code.rb
+++ b/lib/content_block_tools/embed_code.rb
@@ -21,7 +21,7 @@ module ContentBlockTools
   #   embed_code.format #=> "years_short"
   #
   class EmbedCode
-    FORMAT_REGEX = /\|(?<format>[^}]+)}}$/
+    FORMAT_REGEX = /\|(?<format>[^}|]+)}}$/
 
     def initialize(embed_code_string)
       @embed_code_string = embed_code_string

--- a/lib/content_block_tools/format.rb
+++ b/lib/content_block_tools/format.rb
@@ -1,5 +1,5 @@
 module ContentBlockTools
   module Format
-    DEFAULT_FORMAT = "default"
+    DEFAULT_FORMAT = "default".freeze
   end
 end

--- a/lib/content_block_tools/format.rb
+++ b/lib/content_block_tools/format.rb
@@ -1,0 +1,5 @@
+module ContentBlockTools
+  module Format
+    DEFAULT_FORMAT = "default"
+  end
+end

--- a/spec/content_block_tools/components/content_block_tools/time_period_component_spec.rb
+++ b/spec/content_block_tools/components/content_block_tools/time_period_component_spec.rb
@@ -1,12 +1,15 @@
 RSpec.describe ContentBlockTools::TimePeriodComponent do
   describe "#render" do
+    let(:content_id) { SecureRandom.uuid }
+    let(:embed_code) { "{{embed:content_block_time_period:tax-year}}" }
+
     let(:content_block) do
       ContentBlockTools::ContentBlock.new(
         document_type: "time_period",
-        content_id: SecureRandom.uuid,
+        content_id: content_id,
         title: "Tax year",
         details: details,
-        embed_code: "{{embed:content_block_time_period:tax-year}}",
+        embed_code: embed_code,
       )
     end
 
@@ -14,17 +17,124 @@ RSpec.describe ContentBlockTools::TimePeriodComponent do
       described_class.new(content_block: content_block)
     end
 
-    context "with legacy format" do
-      let(:details) do
-        {
-          "date_range" => {
-            "start" => { "date" => "2025-04-06", "time" => "00:00" },
-            "end" => { "date" => "2026-04-05", "time" => "23:59" },
-          },
-        }
+    let(:details) do
+      {
+        "date_range" => {
+          "start" => "2025-04-06T00:00:00+00:00",
+          "end" => "2026-04-05T23:59:00+00:00",
+        },
+      }
+    end
+
+    describe "default format" do
+      it "renders the same output as long_form" do
+        default_block = ContentBlockTools::ContentBlock.new(
+          document_type: "time_period",
+          content_id: SecureRandom.uuid,
+          title: "Tax year",
+          details: details,
+          embed_code: "{{embed:content_block_time_period:tax-year}}",
+        )
+
+        long_form_block = ContentBlockTools::ContentBlock.new(
+          document_type: "time_period",
+          content_id: SecureRandom.uuid,
+          title: "Tax year",
+          details: details,
+          embed_code: "{{embed:content_block_time_period:tax-year|long_form}}",
+        )
+
+        default_component = described_class.new(content_block: default_block)
+        long_form_component = described_class.new(content_block: long_form_block)
+
+        expect(default_component.render).to eq(long_form_component.render)
       end
 
-      it "presents the date range as pair of GovUK formatted dates" do
+      context "with legacy format details" do
+        let(:details) do
+          {
+            "date_range" => {
+              "start" => { "date" => "2025-04-06", "time" => "00:00" },
+              "end" => { "date" => "2026-04-05", "time" => "23:59" },
+            },
+          }
+        end
+
+        it "presents the date range as pair of GovUK formatted dates" do
+          expect(component.render).to have_tag(
+            "p",
+            with: { class: "govuk-body" },
+            seen: "6 April 2025 to 5 April 2026",
+          )
+        end
+      end
+
+      context "with ISO 8601 format details" do
+        it "presents the date range as pair of GovUK formatted dates" do
+          expect(component.render).to have_tag(
+            "p",
+            with: { class: "govuk-body" },
+            seen: "6 April 2025 to 5 April 2026",
+          )
+        end
+      end
+
+      context "when both formats produce identical output" do
+        let(:legacy_details) do
+          {
+            "date_range" => {
+              "start" => { "date" => "2025-04-06", "time" => "00:00" },
+              "end" => { "date" => "2026-04-05", "time" => "23:59" },
+            },
+          }
+        end
+
+        let(:iso8601_details) do
+          {
+            "date_range" => {
+              "start" => "2025-04-06T00:00:00+00:00",
+              "end" => "2026-04-05T23:59:00+00:00",
+            },
+          }
+        end
+
+        it "renders the same output for both formats" do
+          legacy_block = ContentBlockTools::ContentBlock.new(
+            document_type: "time_period",
+            content_id: SecureRandom.uuid,
+            title: "Tax year",
+            details: legacy_details,
+            embed_code: "{{embed:content_block_time_period:tax-year}}",
+          )
+
+          iso8601_block = ContentBlockTools::ContentBlock.new(
+            document_type: "time_period",
+            content_id: SecureRandom.uuid,
+            title: "Tax year",
+            details: iso8601_details,
+            embed_code: "{{embed:content_block_time_period:tax-year}}",
+          )
+
+          legacy_component = described_class.new(content_block: legacy_block)
+          iso8601_component = described_class.new(content_block: iso8601_block)
+
+          expect(legacy_component.render).to eq(iso8601_component.render)
+        end
+      end
+
+      context "when the date range is not defined" do
+        let(:details) { {} }
+
+        it "renders nothing" do
+          expect(component.render).to eq("")
+        end
+      end
+    end
+
+    describe "long_form format" do
+      let(:embed_code) { "{{embed:content_block_time_period:tax-year|long_form}}" }
+
+      it "renders the full date range" do
         expect(component.render).to have_tag(
           "p",
           with: { class: "govuk-body" },
@@ -33,73 +143,74 @@ RSpec.describe ContentBlockTools::TimePeriodComponent do
       end
     end
 
-    context "with ISO 8601 format" do
-      let(:details) do
-        {
-          "date_range" => {
-            "start" => "2025-04-06T00:00:00+00:00",
-            "end" => "2026-04-05T23:59:00+00:00",
-          },
-        }
-      end
+    describe "months_and_years_long format" do
+      let(:embed_code) { "{{embed:content_block_time_period:tax-year|months_and_years_long}}" }
 
-      it "presents the date range as pair of GovUK formatted dates" do
+      it "renders month and year only" do
         expect(component.render).to have_tag(
           "p",
           with: { class: "govuk-body" },
-          seen: "6 April 2025 to 5 April 2026",
+          seen: "April 2025 to April 2026",
         )
       end
     end
 
-    context "when both formats produce identical output" do
-      let(:legacy_details) do
-        {
-          "date_range" => {
-            "start" => { "date" => "2025-04-06", "time" => "00:00" },
-            "end" => { "date" => "2026-04-05", "time" => "23:59" },
-          },
-        }
-      end
+    describe "start_day_and_month format" do
+      let(:embed_code) { "{{embed:content_block_time_period:tax-year|start_day_and_month}}" }
 
-      let(:iso8601_details) do
-        {
-          "date_range" => {
-            "start" => "2025-04-06T00:00:00+00:00",
-            "end" => "2026-04-05T23:59:00+00:00",
-          },
-        }
-      end
-
-      it "renders the same output for both formats" do
-        legacy_block = ContentBlockTools::ContentBlock.new(
-          document_type: "time_period",
-          content_id: SecureRandom.uuid,
-          title: "Tax year",
-          details: legacy_details,
-          embed_code: "{{embed:content_block_time_period:tax-year}}",
+      it "renders only the start day and month" do
+        expect(component.render).to have_tag(
+          "p",
+          with: { class: "govuk-body" },
+          seen: "6 April",
         )
-
-        iso8601_block = ContentBlockTools::ContentBlock.new(
-          document_type: "time_period",
-          content_id: SecureRandom.uuid,
-          title: "Tax year",
-          details: iso8601_details,
-          embed_code: "{{embed:content_block_time_period:tax-year}}",
-        )
-
-        legacy_component = described_class.new(content_block: legacy_block)
-        iso8601_component = described_class.new(content_block: iso8601_block)
-
-        expect(legacy_component.render).to eq(iso8601_component.render)
       end
     end
 
-    context "when the date range is not defined" do
-      let(:details) { {} }
+    describe "start_month_as_word format" do
+      let(:embed_code) { "{{embed:content_block_time_period:tax-year|start_month_as_word}}" }
 
-      it "renders nothing" do
-        expect(component.render).not_to have_tag("p")
+      it "renders only the start month" do
+        expect(component.render).to have_tag(
+          "p",
+          with: { class: "govuk-body" },
+          seen: "April",
+        )
+      end
+    end
+
+    describe "years format" do
+      let(:embed_code) { "{{embed:content_block_time_period:tax-year|years}}" }
+
+      it "renders the year range with full years" do
+        expect(component.render).to have_tag(
+          "p",
+          with: { class: "govuk-body" },
+          seen: "2025-2026",
+        )
+      end
+    end
+
+    describe "years_short format" do
+      let(:embed_code) { "{{embed:content_block_time_period:tax-year|years_short}}" }
+
+      it "renders the year range with abbreviated end year" do
+        expect(component.render).to have_tag(
+          "p",
+          with: { class: "govuk-body" },
+          seen: "2025-26",
+        )
+      end
+    end
+
+    describe "invalid format" do
+      let(:embed_code) { "{{embed:content_block_time_period:tax-year|unknown_format}}" }
+
+      it "raises InvalidFormatError" do
+        expect { component }.to raise_error(
+          ContentBlockTools::InvalidFormatError,
+          "Unknown format 'unknown_format' for time_period",
+        )
       end
     end
   end

--- a/spec/content_block_tools/components/content_block_tools/time_period_component_spec.rb
+++ b/spec/content_block_tools/components/content_block_tools/time_period_component_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ContentBlockTools::TimePeriodComponent do
           content_id: SecureRandom.uuid,
           title: "Tax year",
           details: details,
-          embed_code: "{{embed:content_block_time_period:tax-year|long_form}}",
+          embed_code: "{{embed:content_block_time_period:tax-year#long_form}}",
         )
 
         default_component = described_class.new(content_block: default_block)
@@ -132,7 +132,7 @@ RSpec.describe ContentBlockTools::TimePeriodComponent do
     end
 
     describe "long_form format" do
-      let(:embed_code) { "{{embed:content_block_time_period:tax-year|long_form}}" }
+      let(:embed_code) { "{{embed:content_block_time_period:tax-year#long_form}}" }
 
       it "renders the full date range" do
         expect(component.render).to have_tag(
@@ -144,7 +144,7 @@ RSpec.describe ContentBlockTools::TimePeriodComponent do
     end
 
     describe "months_and_years_long format" do
-      let(:embed_code) { "{{embed:content_block_time_period:tax-year|months_and_years_long}}" }
+      let(:embed_code) { "{{embed:content_block_time_period:tax-year#months_and_years_long}}" }
 
       it "renders month and year only" do
         expect(component.render).to have_tag(
@@ -156,7 +156,7 @@ RSpec.describe ContentBlockTools::TimePeriodComponent do
     end
 
     describe "start_day_and_month format" do
-      let(:embed_code) { "{{embed:content_block_time_period:tax-year|start_day_and_month}}" }
+      let(:embed_code) { "{{embed:content_block_time_period:tax-year#start_day_and_month}}" }
 
       it "renders only the start day and month" do
         expect(component.render).to have_tag(
@@ -168,7 +168,7 @@ RSpec.describe ContentBlockTools::TimePeriodComponent do
     end
 
     describe "start_month_as_word format" do
-      let(:embed_code) { "{{embed:content_block_time_period:tax-year|start_month_as_word}}" }
+      let(:embed_code) { "{{embed:content_block_time_period:tax-year#start_month_as_word}}" }
 
       it "renders only the start month" do
         expect(component.render).to have_tag(
@@ -180,7 +180,7 @@ RSpec.describe ContentBlockTools::TimePeriodComponent do
     end
 
     describe "years format" do
-      let(:embed_code) { "{{embed:content_block_time_period:tax-year|years}}" }
+      let(:embed_code) { "{{embed:content_block_time_period:tax-year#years}}" }
 
       it "renders the year range with full years" do
         expect(component.render).to have_tag(
@@ -192,7 +192,7 @@ RSpec.describe ContentBlockTools::TimePeriodComponent do
     end
 
     describe "years_short format" do
-      let(:embed_code) { "{{embed:content_block_time_period:tax-year|years_short}}" }
+      let(:embed_code) { "{{embed:content_block_time_period:tax-year#years_short}}" }
 
       it "renders the year range with abbreviated end year" do
         expect(component.render).to have_tag(
@@ -204,7 +204,7 @@ RSpec.describe ContentBlockTools::TimePeriodComponent do
     end
 
     describe "invalid format" do
-      let(:embed_code) { "{{embed:content_block_time_period:tax-year|unknown_format}}" }
+      let(:embed_code) { "{{embed:content_block_time_period:tax-year#unknown_format}}" }
 
       it "raises InvalidFormatError" do
         expect { component }.to raise_error(

--- a/spec/content_block_tools/content_block_spec.rb
+++ b/spec/content_block_tools/content_block_spec.rb
@@ -83,6 +83,24 @@ RSpec.describe ContentBlockTools::ContentBlock do
     end
   end
 
+  describe "#format" do
+    context "when embed code has no format specifier" do
+      let(:embed_code) { "{{embed:content_block_time_period:tax-year}}" }
+
+      it "returns the default format" do
+        expect(content_block.format).to eq(ContentBlockTools::Format::DEFAULT_FORMAT)
+      end
+    end
+
+    context "when embed code has a format specifier" do
+      let(:embed_code) { "{{embed:content_block_time_period:tax-year|years_short}}" }
+
+      it "returns the format" do
+        expect(content_block.format).to eq("years_short")
+      end
+    end
+  end
+
   describe ".render" do
     context "with a contact block" do
       let(:expected_wrapper_attributes) do

--- a/spec/content_block_tools/content_block_spec.rb
+++ b/spec/content_block_tools/content_block_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe ContentBlockTools::ContentBlock do
     end
 
     context "when embed code has a format specifier" do
-      let(:embed_code) { "{{embed:content_block_time_period:tax-year|years_short}}" }
+      let(:embed_code) { "{{embed:content_block_time_period:tax-year#years_short}}" }
 
       it "returns the format" do
         expect(content_block.format).to eq("years_short")

--- a/spec/content_block_tools/embed_code_spec.rb
+++ b/spec/content_block_tools/embed_code_spec.rb
@@ -55,4 +55,40 @@ RSpec.describe ContentBlockTools::EmbedCode do
       end
     end
   end
+
+  describe "#format" do
+    context "when no format is specified" do
+      let(:embed_code) { "{{embed:content_block_time_period:tax-year}}" }
+
+      it "returns the default format" do
+        expect(described_class.new(embed_code).format)
+          .to eq(ContentBlockTools::Format::DEFAULT_FORMAT)
+      end
+    end
+
+    context "when a format is specified" do
+      let(:embed_code) { "{{embed:content_block_time_period:tax-year|years_short}}" }
+
+      it "returns the format" do
+        expect(described_class.new(embed_code).format).to eq("years_short")
+      end
+    end
+
+    context "when embed code has fields and a format" do
+      let(:embed_code) { "{{embed:content_block_contact:main-office/email|custom_format}}" }
+
+      it "returns the format" do
+        expect(described_class.new(embed_code).format).to eq("custom_format")
+      end
+    end
+
+    context "when embed code is invalid" do
+      let(:embed_code) { "invalid" }
+
+      it "returns the default format" do
+        expect(described_class.new(embed_code).format)
+          .to eq(ContentBlockTools::Format::DEFAULT_FORMAT)
+      end
+    end
+  end
 end

--- a/spec/content_block_tools/embed_code_spec.rb
+++ b/spec/content_block_tools/embed_code_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe ContentBlockTools::EmbedCode do
     end
 
     context "when a format is specified" do
-      let(:embed_code) { "{{embed:content_block_time_period:tax-year|years_short}}" }
+      let(:embed_code) { "{{embed:content_block_time_period:tax-year#years_short}}" }
 
       it "returns the format" do
         expect(described_class.new(embed_code).format).to eq("years_short")
@@ -75,7 +75,7 @@ RSpec.describe ContentBlockTools::EmbedCode do
     end
 
     context "when embed code has fields and a format" do
-      let(:embed_code) { "{{embed:content_block_contact:main-office/email|custom_format}}" }
+      let(:embed_code) { "{{embed:content_block_contact:main-office/email#custom_format}}" }
 
       it "returns the format" do
         expect(described_class.new(embed_code).format).to eq("custom_format")

--- a/spec/content_block_tools/format_spec.rb
+++ b/spec/content_block_tools/format_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe ContentBlockTools::Format do
+  describe "DEFAULT_FORMAT" do
+    it "is 'default'" do
+      expect(ContentBlockTools::Format::DEFAULT_FORMAT).to eq("default")
+    end
+  end
+end


### PR DESCRIPTION
This is part 3 of three new PRs resulting from the experimental https://github.com/alphagov/govuk_content_block_tools/pull/141 work:

1. ✅  PR 146: Initial refactoring which is of immediate value and also prepares for the following feature
PR https://github.com/alphagov/govuk_content_block_tools/pull/146, which we plan to merge right away, once reviewed

2. ✅  Refactoring 2: [PR 150](https://github.com/alphagov/govuk_content_block_tools/pull/150) replacing field_names with InternalContentPath
[PR 150](https://github.com/alphagov/govuk_content_block_tools/pull/150) which can also be merged once reviewed as it brings a immediate improvement in clarity.

3. **This PR**, adding support for "format" specifier in embed code
Building on the initial refactoring. To be merged once reviewed and discussed. It does not introduce any breaking changes so should be safe to merge as soon as agreed and discussed.

This PR allow us to define a optional "format" in the embed code. To illustrate, we add support for a few formats which might be required by `TimePeriod`:

```
Supported formats:
- long_form: '6 April 2025 to 5 April 2026'
- months_and_years_long: 'April 2025 to April 2026'
- start_day_and_month: '6 April'
- start_month_as_word: 'April'
- years: '2025-2026'
- years_short: '2025-26'
```

We also demonstrate how we can render format-specific templates. This is probably overkill for `TimePeriod`, but serves to illustrate the pattern we could use for complex blocks such as `Contact` and `Tax` where each format will deserve its own template file.

