### PR TITLE
(CM-865) Refactor 2: replace "field_names" list with  InternalContentPath object

### DIFF
--- a/lib/content_block_tools.rb
+++ b/lib/content_block_tools.rb
@@ -19,6 +19,7 @@ require "content_block_tools/presenters/field_presenters/time_period/end_present
 require "content_block_tools/content_block"
 require "content_block_tools/content_block_reference"
 require "content_block_tools/embed_code"
+require "content_block_tools/internal_content_path"
 require "content_block_tools/normalised_date_range"
 require "content_block_tools/renderer"
 

--- a/lib/content_block_tools/content_block_reference.rb
+++ b/lib/content_block_tools/content_block_reference.rb
@@ -40,10 +40,10 @@ module ContentBlockTools
     UUID_REGEX = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
     # The regex used to find content ID aliases
     CONTENT_ID_ALIAS_REGEX = /[a-z0-9\-–—]+/
-    # The regex to find optional field names after the UUID, begins with '/'
-    FIELD_REGEX = /(?<fields>\/[a-z0-9_\-–—\/]*)?/
+    # The regex to find optional internal content path after the UUID, begins with '/'
+    INTERNAL_CONTENT_PATH_REGEX = /(?<internal_content_path>\/[a-z0-9_\-–—\/]*)?/
     # The regex used when scanning a document using {ContentBlockTools::ContentBlockReference.find_all_in_document}
-    EMBED_REGEX = /(?<embed_code>{{embed:(?<document_type>#{SUPPORTED_DOCUMENT_TYPES.join('|')}):(?<identifier>#{UUID_REGEX}|#{CONTENT_ID_ALIAS_REGEX})#{FIELD_REGEX}}})/
+    EMBED_REGEX = /(?<embed_code>{{embed:(?<document_type>#{SUPPORTED_DOCUMENT_TYPES.join('|')}):(?<identifier>#{UUID_REGEX}|#{CONTENT_ID_ALIAS_REGEX})#{INTERNAL_CONTENT_PATH_REGEX}}})/
 
     # Returns if the identifier is an alias
     #
@@ -108,7 +108,7 @@ module ContentBlockTools
       # markdown parsing) before creating the object.
       #
       # @param match_data [MatchData] the match data from scanning with {EMBED_REGEX}
-      #   Expected named captures: embed_code, document_type, identifier, fields
+      #   Expected named captures: embed_code, document_type, identifier, internal_content_path
       # @example Creating from match data
       #   match_data = "{{embed:content_block_pension:2b92cade-549c-4449-9796-e7a3957f3a86}}".match(EMBED_REGEX)
       #   ContentBlockReference.from_match_data(match_data)
@@ -138,7 +138,7 @@ module ContentBlockTools
           embed_code: match[:embed_code],
           document_type: match[:document_type],
           identifier: replace_dashes(match[:identifier]),
-          fields: match[:fields],
+          internal_content_path: match[:internal_content_path],
         }
       end
 

--- a/lib/content_block_tools/embed_code.rb
+++ b/lib/content_block_tools/embed_code.rb
@@ -29,6 +29,13 @@ module ContentBlockTools
       @field_names ||= parse_field_names
     end
 
+    # Returns the internal content path for this embed code
+    #
+    # @return [InternalContentPath] The path to internal content
+    def internal_content_path
+      @internal_content_path ||= InternalContentPath.new(field_names)
+    end
+
   private
 
     attr_reader :embed_code_string

--- a/lib/content_block_tools/embed_code.rb
+++ b/lib/content_block_tools/embed_code.rb
@@ -34,7 +34,7 @@ module ContentBlockTools
       match = ContentBlockReference::EMBED_REGEX.match(embed_code_string)
       return [] unless match
 
-      all_segments = strip_leading_slash(match[:fields])
+      all_segments = strip_leading_slash(match[:internal_content_path])
       return [] if all_segments.nil?
 
       all_segments.split("/").map { |item| convert_segment(item) }

--- a/lib/content_block_tools/embed_code.rb
+++ b/lib/content_block_tools/embed_code.rb
@@ -8,49 +8,43 @@ module ContentBlockTools
   #
   # @example Basic embed code
   #   embed_code = EmbedCode.new("{{embed:content_block_contact:main-office}}")
-  #   embed_code.field_names #=> []
+  #   embed_code.internal_content_path.present? #=> false
   #
   # @example Embed code with field path
   #   embed_code = EmbedCode.new("{{embed:content_block_contact:main-office/email_addresses/main}}")
-  #   embed_code.field_names #=> [:email_addresses, :main]
+  #   embed_code.internal_content_path.path #=> [:email_addresses, :main]
   #
   class EmbedCode
     def initialize(embed_code_string)
       @embed_code_string = embed_code_string
     end
 
-    # Returns the field names extracted from the embed code path
-    #
-    # Field names are the path components after the identifier, converted to symbols
-    # or integers as appropriate.
-    #
-    # @return [Array<Symbol, Integer>] The field names, or [] if no path
-    def field_names
-      @field_names ||= parse_field_names
-    end
-
     # Returns the internal content path for this embed code
     #
     # @return [InternalContentPath] The path to internal content
     def internal_content_path
-      @internal_content_path ||= InternalContentPath.new(field_names)
+      @internal_content_path ||= InternalContentPath.new(parse_path_segments)
     end
 
   private
 
     attr_reader :embed_code_string
 
-    def parse_field_names
+    def parse_path_segments
       match = ContentBlockReference::EMBED_REGEX.match(embed_code_string)
       return [] unless match
 
-      all_fields = match[:fields]&.reverse&.chomp("/")&.reverse
-      return [] if all_fields.nil?
+      all_segments = strip_leading_slash(match[:fields])
+      return [] if all_segments.nil?
 
-      all_fields.split("/").map { |item| convert_field_item(item) }
+      all_segments.split("/").map { |item| convert_segment(item) }
     end
 
-    def convert_field_item(item)
+    def strip_leading_slash(path)
+      path&.reverse&.chomp("/")&.reverse
+    end
+
+    def convert_segment(item)
       numeric?(item) ? item.to_i : item.to_sym
     end
 

--- a/lib/content_block_tools/internal_content_path.rb
+++ b/lib/content_block_tools/internal_content_path.rb
@@ -1,0 +1,49 @@
+module ContentBlockTools
+  # Represents the path to internal content within a content block
+  #
+  # An internal content path identifies a specific piece of content within a
+  # content block's details hash. The path is used with `dig` to traverse the
+  # nested structure.
+  #
+  # @example Path to a block
+  #   path = InternalContentPath.new([:email_addresses, :main])
+  #   path.present?    #=> true
+  #   path.singular?   #=> false
+  #   path.block_type  #=> :email_addresses
+  #   path.block_name  #=> :main
+  #
+  # @example Path to a field in a one-to-one relationship
+  #   path = InternalContentPath.new([:date_range])
+  #   path.singular?   #=> true
+  #   path.block_type  #=> :date_range
+  #   path.block_name  #=> :date_range
+  #
+  # @example Empty path (render the whole block)
+  #   path = InternalContentPath.new([])
+  #   path.present?    #=> false
+  #   path.block_type  #=> nil
+  #
+  class InternalContentPath
+    attr_reader :path
+
+    def initialize(path)
+      @path = path
+    end
+
+    def present?
+      path.any?
+    end
+
+    def singular?
+      path.one?
+    end
+
+    def block_type
+      path.first
+    end
+
+    def block_name
+      path.last
+    end
+  end
+end

--- a/lib/content_block_tools/renderer.rb
+++ b/lib/content_block_tools/renderer.rb
@@ -44,17 +44,17 @@ module ContentBlockTools
     end
 
     def content
-      field_names.present? ? field_or_block_content : component.new(content_block:).render
+      internal_content_path.present? ? field_or_block_content : component.new(content_block:).render
     rescue UnknownComponentError
       content_block.title
     end
 
     def field_or_block_content
-      field_content = content_block.details.dig(*field_names)
+      field_content = content_block.details.dig(*internal_content_path.path)
 
       case field_content
       when String
-        field_presenter(field_names.last).new(field_content).render
+        field_presenter(internal_content_path.block_name).new(field_content).render
       when Hash
         render_hash_content(field_content)
       else
@@ -64,29 +64,26 @@ module ContentBlockTools
     end
 
     def render_hash_content(field_content)
-      if embedded_object_in_one_to_one_relationship?
-        field_presenter(field_names.last).new(field_content).render
+      if internal_content_path.singular?
+        field_presenter(internal_content_path.block_name).new(field_content).render
       else
         component.new(
           content_block:,
-          block_type: field_names.first,
-          block_name: field_names.last,
+          block_type: internal_content_path.block_type,
+          block_name: internal_content_path.block_name,
         ).render
       end
     end
 
     def log_content_not_found
       ContentBlockTools.logger.warn(
-        "Content not found for content block #{content_block.content_id} and fields #{field_names}",
+        "Content not found for content block #{content_block.content_id} " \
+        "and fields #{internal_content_path.path}",
       )
     end
 
-    def embedded_object_in_one_to_one_relationship?
-      field_names.one?
-    end
-
     def rendering_block?
-      !field_names.present? || content_block.details.dig(*field_names).is_a?(Hash)
+      !internal_content_path.present? || content_block.details.dig(*internal_content_path.path).is_a?(Hash)
     end
 
     def component
@@ -103,8 +100,8 @@ module ContentBlockTools
       ContentBlockTools::Presenters::FieldPresenters::BasePresenter
     end
 
-    def field_names
-      @field_names ||= EmbedCode.new(content_block.embed_code).field_names
+    def internal_content_path
+      @internal_content_path ||= EmbedCode.new(content_block.embed_code).internal_content_path
     end
   end
 end

--- a/spec/content_block_tools/content_block_reference_spec.rb
+++ b/spec/content_block_tools/content_block_reference_spec.rb
@@ -79,8 +79,8 @@ RSpec.describe ContentBlockTools::ContentBlockReference do
 
       describe "#content_references" do
         it "returns all references" do
-          expect(ContentBlockTools.logger).to receive(:info).with("Found Content Block Reference: {:embed_code=>\"{{embed:contact:#{contact_uuid}}}\", :document_type=>\"contact\", :identifier=>\"#{contact_uuid}\", :fields=>nil}")
-          expect(ContentBlockTools.logger).to receive(:info).with("Found Content Block Reference: {:embed_code=>\"{{embed:content_block_pension:#{content_block_pension_uuid}}}\", :document_type=>\"content_block_pension\", :identifier=>\"#{content_block_pension_uuid}\", :fields=>nil}")
+          expect(ContentBlockTools.logger).to receive(:info).with("Found Content Block Reference: {:embed_code=>\"{{embed:contact:#{contact_uuid}}}\", :document_type=>\"contact\", :identifier=>\"#{contact_uuid}\", :internal_content_path=>nil}")
+          expect(ContentBlockTools.logger).to receive(:info).with("Found Content Block Reference: {:embed_code=>\"{{embed:content_block_pension:#{content_block_pension_uuid}}}\", :document_type=>\"content_block_pension\", :identifier=>\"#{content_block_pension_uuid}\", :internal_content_path=>nil}")
 
           expect(result.count).to eq(2)
 
@@ -155,8 +155,8 @@ RSpec.describe ContentBlockTools::ContentBlockReference do
 
       describe "#content_references" do
         it "returns all references" do
-          expect(ContentBlockTools.logger).to receive(:info).with("Found Content Block Reference: {:embed_code=>\"{{embed:contact:#{contact_alias}}}\", :document_type=>\"contact\", :identifier=>\"#{contact_alias}\", :fields=>nil}")
-          expect(ContentBlockTools.logger).to receive(:info).with("Found Content Block Reference: {:embed_code=>\"{{embed:content_block_pension:#{content_block_pension_alias}}}\", :document_type=>\"content_block_pension\", :identifier=>\"#{content_block_pension_alias}\", :fields=>nil}")
+          expect(ContentBlockTools.logger).to receive(:info).with("Found Content Block Reference: {:embed_code=>\"{{embed:contact:#{contact_alias}}}\", :document_type=>\"contact\", :identifier=>\"#{contact_alias}\", :internal_content_path=>nil}")
+          expect(ContentBlockTools.logger).to receive(:info).with("Found Content Block Reference: {:embed_code=>\"{{embed:content_block_pension:#{content_block_pension_alias}}}\", :document_type=>\"content_block_pension\", :identifier=>\"#{content_block_pension_alias}\", :internal_content_path=>nil}")
 
           expect(result.count).to eq(2)
 

--- a/spec/content_block_tools/embed_code_spec.rb
+++ b/spec/content_block_tools/embed_code_spec.rb
@@ -40,4 +40,21 @@ RSpec.describe ContentBlockTools::EmbedCode do
       end
     end
   end
+
+  describe "#internal_content_path" do
+    it "returns an InternalContentPath with the field names" do
+      embed_code = described_class.new("{{embed:content_block_contact:main-office/email_addresses/main}}")
+      path = embed_code.internal_content_path
+
+      expect(path).to be_a(ContentBlockTools::InternalContentPath)
+      expect(path.path).to eq(%i[email_addresses main])
+    end
+
+    it "returns an empty InternalContentPath when no field path" do
+      embed_code = described_class.new("{{embed:content_block_contact:main-office}}")
+      path = embed_code.internal_content_path
+
+      expect(path).not_to be_present
+    end
+  end
 end

--- a/spec/content_block_tools/embed_code_spec.rb
+++ b/spec/content_block_tools/embed_code_spec.rb
@@ -1,10 +1,16 @@
 RSpec.describe ContentBlockTools::EmbedCode do
-  describe "#field_names" do
+  describe "#internal_content_path" do
+    subject(:path) { described_class.new(embed_code).internal_content_path }
+
     context "when embed code has no field path" do
       let(:embed_code) { "{{embed:content_block_contact:main-office}}" }
 
-      it "returns an empty array" do
-        expect(described_class.new(embed_code).field_names).to eq([])
+      it "returns an empty path" do
+        expect(path.path).to eq([])
+      end
+
+      it "is not present" do
+        expect(path).not_to be_present
       end
     end
 
@@ -12,7 +18,11 @@ RSpec.describe ContentBlockTools::EmbedCode do
       let(:embed_code) { "{{embed:content_block_contact:main-office/email}}" }
 
       it "returns the field as a symbol" do
-        expect(described_class.new(embed_code).field_names).to eq([:email])
+        expect(path.path).to eq([:email])
+      end
+
+      it "is singular" do
+        expect(path).to be_singular
       end
     end
 
@@ -20,7 +30,12 @@ RSpec.describe ContentBlockTools::EmbedCode do
       let(:embed_code) { "{{embed:content_block_contact:main-office/email_addresses/main}}" }
 
       it "returns all fields as symbols" do
-        expect(described_class.new(embed_code).field_names).to eq(%i[email_addresses main])
+        expect(path.path).to eq(%i[email_addresses main])
+      end
+
+      it "exposes block_type and block_name" do
+        expect(path.block_type).to eq(:email_addresses)
+        expect(path.block_name).to eq(:main)
       end
     end
 
@@ -28,33 +43,16 @@ RSpec.describe ContentBlockTools::EmbedCode do
       let(:embed_code) { "{{embed:content_block_contact:main-office/email_addresses/0/email}}" }
 
       it "converts numeric segments to integers" do
-        expect(described_class.new(embed_code).field_names).to eq([:email_addresses, 0, :email])
+        expect(path.path).to eq([:email_addresses, 0, :email])
       end
     end
 
     context "when embed code is invalid" do
       let(:embed_code) { "invalid" }
 
-      it "returns an empty list" do
-        expect(described_class.new(embed_code).field_names).to be_empty
+      it "returns an empty path" do
+        expect(path.path).to be_empty
       end
-    end
-  end
-
-  describe "#internal_content_path" do
-    it "returns an InternalContentPath with the field names" do
-      embed_code = described_class.new("{{embed:content_block_contact:main-office/email_addresses/main}}")
-      path = embed_code.internal_content_path
-
-      expect(path).to be_a(ContentBlockTools::InternalContentPath)
-      expect(path.path).to eq(%i[email_addresses main])
-    end
-
-    it "returns an empty InternalContentPath when no field path" do
-      embed_code = described_class.new("{{embed:content_block_contact:main-office}}")
-      path = embed_code.internal_content_path
-
-      expect(path).not_to be_present
     end
   end
 end

--- a/spec/content_block_tools/internal_content_path_spec.rb
+++ b/spec/content_block_tools/internal_content_path_spec.rb
@@ -1,0 +1,97 @@
+RSpec.describe ContentBlockTools::InternalContentPath do
+  describe "#path" do
+    it "returns the path array" do
+      path = described_class.new(%i[email_addresses main])
+      expect(path.path).to eq(%i[email_addresses main])
+    end
+  end
+
+  describe "#present?" do
+    let(:path) { described_class.new([:email_addresses]) }
+
+    context "when path has segments" do
+      it "returns true" do
+        expect(path).to be_present
+      end
+    end
+
+    context "when path is empty" do
+      let(:path) { described_class.new([]) }
+
+      it "returns false" do
+        path = described_class.new([])
+        expect(path).not_to be_present
+      end
+    end
+  end
+
+  describe "#singular?" do
+    context "when path has one segment" do
+      let(:path) { described_class.new([:date_range]) }
+
+      it "returns true" do
+        expect(path).to be_singular
+      end
+    end
+
+    context "when path has multiple segments" do
+      let(:path) { described_class.new(%i[email_addresses main]) }
+
+      it "returns false" do
+        expect(path).not_to be_singular
+      end
+    end
+
+    context "when path is empty" do
+      let(:path) { described_class.new([]) }
+
+      it "returns false" do
+        expect(path).not_to be_singular
+      end
+    end
+  end
+
+  describe "#block_type" do
+    context "when path has segments" do
+      let(:path) { described_class.new(%i[email_addresses main]) }
+
+      it "returns the first segment" do
+        expect(path.block_type).to eq(:email_addresses)
+      end
+    end
+
+    context "when path is empty" do
+      let(:path) { described_class.new([]) }
+
+      it "returns nil" do
+        expect(path.block_type).to be_nil
+      end
+    end
+  end
+
+  describe "#block_name" do
+    context "when path has multiple segments" do
+      let(:path) { described_class.new(%i[email_addresses main]) }
+
+      it "returns the last segment" do
+        expect(path.block_name).to eq(:main)
+      end
+    end
+
+    context "when path has one segment" do
+      let(:path) { described_class.new([:date_range]) }
+
+      it "returns that segment" do
+        expect(path.block_name).to eq(:date_range)
+      end
+    end
+
+    context "when path is empty" do
+      let(:path) { described_class.new([]) }
+
+      it "returns nil" do
+        expect(path.block_name).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is part 2 in a 3 step sequence toward introducing format specifiers:

1. ✅  Extract EmbedCode and Renderer classes [PR 146](https://github.com/alphagov/govuk_content_block_tools/pull/146)
2. **This refactoring PR** replacing `field_names` with `InternalContentPath`
3. Implement "format specifier" [PR 147](https://github.com/alphagov/govuk_content_block_tools/pull/147)



---

Reviewing the new `EmbedCode` class we see that the "field_names" list brought over from the original `ContentBlock` class is a bit obscure as:

- the portion of the embed code describing content within the block (such as `main-office/email_addresses/0/email` or `main-office/email_addresses/main`) is not so much a list of **field names** as a **path** to a particular subset of the block
- we're using elements in the list of `field_names` according to their position rather than with intention-revealing names. 

So to make the code more explicit,  we now model `InternalContentPath` within `EmbedCode` and expose `#internal_content_path` rather than `#field_names`. We can now use descriptive properties on `InternalContentPath` rather than positionally identified members of the `field_names` list:

- `present?`
- `singular?`
- `block_type`
- `block_name` and
- `path` for the full list of 'segments'
