### PR TITLE
Release v1.12.0 (minor, backwards compatible)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 11.12.0
+
+* Add support for "format specifier" to embed code [#153](https://github.
+  com/alphagov/govuk_content_block_tools/pull/153))
+
 # 1.11.0
 
 * Add dual-format support for `TimePeriod#date_range` - accepts both legacy nested 

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "1.11.0"
+  VERSION = "1.12.0"
 end


### PR DESCRIPTION
## Release minor version 1.12.0

We bump the version releasing the recent work to support encoding a "format specifier" with the embed code. This is backwards compatible. The format specifier is an optional additional element to the embed code. e.g.

Previously without:

```
{{embed:content_block_time_period:tax-year}}
```

Now, optionally with:

```
{{embed:content_block_time_period:tax-year#long_form}}
```
