### PR TITLE
(CM-932) Offer "tax table" format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 11.13.0
+
+* Add "tax_table" format rendering for tax blocks [#155](https://github.com/alphagov/govuk_content_block_tools/pull/155)
+
 ## 1.12.2
 
 * Add data attributes to identify contact parts

--- a/app/components/content_block_tools/tax/tax_table_component.html.erb
+++ b/app/components/content_block_tools/tax/tax_table_component.html.erb
@@ -1,0 +1,18 @@
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <% table_head.each do |header| %>
+        <th scope="col" class="govuk-table__header"><%= header[:text] %></th>
+      <% end %>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% table_rows.each do |row| %>
+      <tr class="govuk-table__row">
+        <% row.each do |cell| %>
+          <td class="govuk-table__cell"><%= cell[:text] %></td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/components/content_block_tools/tax/tax_table_component.rb
+++ b/app/components/content_block_tools/tax/tax_table_component.rb
@@ -1,0 +1,73 @@
+module ContentBlockTools
+  module Tax
+    class TaxTableComponent < ContentBlockTools::BaseComponent
+      def initialize(rates:)
+        @rates = rates
+      end
+
+      def render
+        render_in(view_context)
+      end
+
+    private
+
+      attr_reader :rates
+
+      def table_head
+        [
+          { text: "Band" },
+          { text: "Taxable income" },
+          { text: "Tax rate" },
+        ]
+      end
+
+      def table_rows
+        rates.each_with_index.map do |rate, index|
+          [
+            { text: band_name(rate) },
+            { text: taxable_income_text(rate, index) },
+            { text: rate_value(rate) },
+          ]
+        end
+      end
+
+      def band_name(rate)
+        rate.dig(:bands, 0, :name)
+      end
+
+      def rate_value(rate)
+        rate[:value]
+      end
+
+      def taxable_income_text(rate, index)
+        if only_one_rate? || last_row?(index)
+          "over #{lower_threshold(rate)}"
+        elsif first_row?(index)
+          "Up to #{upper_threshold(rate)}"
+        else
+          "#{lower_threshold(rate)} to #{upper_threshold(rate)}"
+        end
+      end
+
+      def only_one_rate?
+        rates.length == 1
+      end
+
+      def first_row?(index)
+        index.zero?
+      end
+
+      def last_row?(index)
+        index == rates.length - 1
+      end
+
+      def lower_threshold(rate)
+        rate.dig(:bands, 0, :lower_threshold, :value)
+      end
+
+      def upper_threshold(rate)
+        rate.dig(:bands, 0, :upper_threshold, :value)
+      end
+    end
+  end
+end

--- a/app/components/content_block_tools/tax_component.rb
+++ b/app/components/content_block_tools/tax_component.rb
@@ -8,6 +8,7 @@ module ContentBlockTools
     def initialize(content_block:, _block_type: nil, _block_name: nil)
       @content_block = content_block
       validate_format!
+      validate_presence_of_income_tax_rates! if tax_table_format?
     end
 
     def render
@@ -18,12 +19,27 @@ module ContentBlockTools
 
     attr_reader :content_block
 
-    delegate :format, to: :content_block
+    delegate :format, :details, to: :content_block
 
     def validate_format!
       return if SUPPORTED_FORMATS.include?(format)
 
       raise InvalidFormatError, "Unknown format '#{format}' for tax"
+    end
+
+    def validate_presence_of_income_tax_rates!
+      return if income_tax_rates&.any?
+
+      raise InvalidFormatError,
+            "Cannot render 'tax_table' format: missing income tax rates"
+    end
+
+    def tax_table_format?
+      format == "tax_table"
+    end
+
+    def income_tax_rates
+      details.dig(:things_taxed, :income, :rates)
     end
   end
 end

--- a/app/components/content_block_tools/tax_component.rb
+++ b/app/components/content_block_tools/tax_component.rb
@@ -1,0 +1,29 @@
+module ContentBlockTools
+  class TaxComponent < ContentBlockTools::BaseComponent
+    SUPPORTED_FORMATS = %w[
+      default
+      tax_table
+    ].freeze
+
+    def initialize(content_block:, _block_type: nil, _block_name: nil)
+      @content_block = content_block
+      validate_format!
+    end
+
+    def render
+      ""
+    end
+
+  private
+
+    attr_reader :content_block
+
+    delegate :format, to: :content_block
+
+    def validate_format!
+      return if SUPPORTED_FORMATS.include?(format)
+
+      raise InvalidFormatError, "Unknown format '#{format}' for tax"
+    end
+  end
+end

--- a/app/components/content_block_tools/tax_component.rb
+++ b/app/components/content_block_tools/tax_component.rb
@@ -12,7 +12,9 @@ module ContentBlockTools
     end
 
     def render
-      ""
+      return "" unless tax_table_format?
+
+      Tax::TaxTableComponent.new(rates: income_tax_rates).render
     end
 
   private

--- a/content_block_tools.gemspec
+++ b/content_block_tools.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]
 
+  spec.add_development_dependency "capybara"
   spec.add_development_dependency "cucumber", "~> 11.0"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake", "13.4.2"

--- a/features/step_definitions/tax_steps.rb
+++ b/features/step_definitions/tax_steps.rb
@@ -1,0 +1,101 @@
+Given("a tax content block with income tax rates") do
+  @content_block_details = {
+    tax_type: "Tax",
+    things_taxed: {
+      income: {
+        title: "Income",
+        type: "Income",
+        rates: [
+          {
+            name: "Zero rate",
+            value: "0%",
+            bands: [
+              {
+                name: "Personal Allowance",
+                lower_threshold: { show: true, value: "£0" },
+                upper_threshold: { show: true, value: "£12,570" },
+              },
+            ],
+          },
+          {
+            name: "Basic rate",
+            value: "20%",
+            bands: [
+              {
+                name: "Basic rate",
+                lower_threshold: { show: true, value: "£12,571" },
+                upper_threshold: { show: true, value: "£50,270" },
+              },
+            ],
+          },
+          {
+            name: "Higher Rate",
+            value: "40%",
+            bands: [
+              {
+                name: "Higher rate",
+                lower_threshold: { show: true, value: "£50,271" },
+                upper_threshold: { show: true, value: "£125,140" },
+              },
+            ],
+          },
+          {
+            name: "Additional rate",
+            value: "45%",
+            bands: [
+              {
+                name: "Additional rate",
+                lower_threshold: { show: true, value: "£125,140" },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  }
+end
+
+Given("a tax content block without income data") do
+  @content_block_details = {
+    tax_type: "Tax",
+    things_taxed: {},
+  }
+end
+
+When("asked to render tax with embed code {string}") do |embed_code|
+  @embed_code = embed_code
+  @content_block = ContentBlockTools::ContentBlock.new(
+    document_type: "content_block_tax",
+    content_id: SecureRandom.uuid,
+    title: "Income Tax",
+    details: @content_block_details,
+    embed_code: @embed_code,
+  )
+
+  begin
+    @rendered = @content_block.render
+    @error = nil
+  rescue ContentBlockTools::InvalidFormatError => e
+    @error = e
+    @rendered = nil
+  end
+end
+
+Then("the rendered output should be a table with headers:") do |table|
+  expect(@error).to be_nil, "Expected no error but got: #{@error&.message}"
+
+  headers = table.raw.first
+  headers.each do |header|
+    expect(@rendered).to have_tag("th", text: header)
+  end
+end
+
+Then("the table should have the following rows:") do |table|
+  expect(@error).to be_nil, "Expected no error but got: #{@error&.message}"
+
+  table.raw.each do |row|
+    row.each do |cell|
+      expect(@rendered).to have_tag("td", text: cell)
+    end
+  end
+end

--- a/features/tax_rendering.feature
+++ b/features/tax_rendering.feature
@@ -1,0 +1,25 @@
+Feature: Tax rendering
+  So that an editor can easily embed a table of income tax rates and bands
+  As a content editor
+  I want to embed an income tax table with a single embed code using a format
+
+  Scenario: Render income tax table with tax_table format
+    Given a tax content block with income tax rates
+    When asked to render tax with embed code "{{embed:content_block_tax:income-tax#tax_table}}"
+    Then the rendered output should be a table with headers:
+      | Band | Taxable income | Tax rate |
+    And the table should have the following rows:
+      | Personal Allowance | Up to £12,570       | 0%  |
+      | Basic rate         | £12,571 to £50,270  | 20% |
+      | Higher rate        | £50,271 to £125,140 | 40% |
+      | Additional rate    | over £125,140       | 45% |
+
+  Scenario: Raise error for invalid format
+    Given a tax content block with income tax rates
+    When asked to render tax with embed code "{{embed:content_block_tax:income-tax#unknown_format}}"
+    Then an InvalidFormatError should be raised with message "Unknown format 'unknown_format' for tax"
+
+  Scenario: Raise error when income tax data is missing
+    Given a tax content block without income data
+    When asked to render tax with embed code "{{embed:content_block_tax:other-tax#tax_table}}"
+    Then an InvalidFormatError should be raised with message "Cannot render 'tax_table' format: missing income tax rates"

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "1.12.2"
+  VERSION = "1.13.0"
 end

--- a/spec/content_block_tools/components/content_block_tools/tax/tax_table_component_spec.rb
+++ b/spec/content_block_tools/components/content_block_tools/tax/tax_table_component_spec.rb
@@ -1,0 +1,178 @@
+RSpec.describe ContentBlockTools::Tax::TaxTableComponent do
+  let(:rates) do
+    [
+      {
+        name: "Zero rate",
+        value: "0%",
+        bands: [
+          {
+            name: "Personal Allowance",
+            lower_threshold: { value: "£0" },
+            upper_threshold: { value: "£12,570" },
+          },
+        ],
+      },
+      {
+        name: "Basic rate",
+        value: "20%",
+        bands: [
+          {
+            name: "Basic rate",
+            lower_threshold: { value: "£12,571" },
+            upper_threshold: { value: "£50,270" },
+          },
+        ],
+      },
+      {
+        name: "Higher rate",
+        value: "40%",
+        bands: [
+          {
+            name: "Higher rate",
+            lower_threshold: { value: "£50,271" },
+            upper_threshold: { value: "£125,140" },
+          },
+        ],
+      },
+      {
+        name: "Additional rate",
+        value: "45%",
+        bands: [
+          {
+            name: "Additional rate",
+            lower_threshold: { value: "£125,140" },
+          },
+        ],
+      },
+    ]
+  end
+
+  let(:component) { described_class.new(rates:) }
+
+  describe "#render" do
+    let(:html) { Capybara.string(component.render) }
+
+    it "renders using the govuk_publishing_components table" do
+      expect(html).to have_css("table.govuk-table")
+    end
+
+    context "header row" do
+      let(:header_row) { html.first("thead tr") }
+
+      it "renders table headers" do
+        expect(header_row).to have_css("th", text: "Band")
+        expect(header_row).to have_css("th", text: "Taxable income")
+        expect(header_row).to have_css("th", text: "Tax rate")
+      end
+    end
+
+    it "renders the expected number of tax band rows" do
+      expect(html).to have_css("tbody tr", count: 4)
+    end
+
+    describe "first (personal allowance) row (with upper threshold only)" do
+      let(:first_row) { html.first("tbody tr") }
+
+      it "renders the band name" do
+        expect(first_row).to have_css("td", text: "Personal Allowance")
+      end
+
+      it "renders 'Up to' with upper threshold" do
+        expect(first_row).to have_css("td", text: "Up to £12,570")
+      end
+
+      it "renders the tax rate" do
+        expect(first_row).to have_css("td", text: "0%")
+      end
+    end
+
+    describe "middle rows (with both thresholds)" do
+      let(:basic_rate_row) { html.all("tbody tr")[1] }
+      let(:higher_rate_row) { html.all("tbody tr")[2] }
+
+      context "basic rate" do
+        it "renders threshold range for basic rate" do
+          expect(basic_rate_row).to have_css("td", text: "£12,571 to £50,270")
+        end
+
+        it "renders rate for basic rate" do
+          expect(basic_rate_row).to have_css("td", text: "20%")
+        end
+      end
+
+      context "higher rate" do
+        it "renders threshold range for higher rate" do
+          expect(higher_rate_row).to have_css("td", text: "£50,271 to £125,140")
+        end
+
+        it "renders rate for basic rate" do
+          expect(higher_rate_row).to have_css("td", text: "40%")
+        end
+      end
+    end
+
+    describe "first (additional rate) row (with lower threshold only)" do
+      let(:additional_rate_row) { html.all("tbody tr").last }
+
+      it "renders the band name" do
+        expect(additional_rate_row).to have_css("td", text: "Additional rate")
+      end
+
+      it "renders 'over' with lower threshold" do
+        expect(additional_rate_row).to have_css("td", text: "over £125,140")
+      end
+
+      it "renders the tax rate" do
+        expect(additional_rate_row).to have_css("td", text: "45%")
+      end
+    end
+
+    describe "edge cases (outside of current income tax table needs)" do
+      context "when only a single rate is defined" do
+        let(:rates) do
+          [
+            {
+              name: "Flat rate",
+              value: "10%",
+              bands: [
+                {
+                  name: "All income",
+                  lower_threshold: { value: "£0" },
+                },
+              ],
+            },
+          ]
+        end
+
+        it "renders the single row with 'over' prefix" do
+          expect(html).to have_css("td", text: "over £0")
+        end
+      end
+
+      context "when two rates are defined" do
+        let(:rates) do
+          [
+            {
+              name: "Basic",
+              value: "0%",
+              bands: [{ name: "Allowance", upper_threshold: { value: "£10,000" } }],
+            },
+            {
+              name: "Standard",
+              value: "20%",
+              bands: [{ name: "Standard", lower_threshold: { value: "£10,001" } }],
+            },
+          ]
+        end
+
+        it "renders first row with 'Up to' prefix" do
+          expect(html).to have_css("td", text: "Up to £10,000")
+        end
+
+        it "renders last row with 'over' prefix" do
+          expect(html).to have_css("td", text: "over £10,001")
+        end
+      end
+    end
+  end
+end

--- a/spec/content_block_tools/components/content_block_tools/tax_component_spec.rb
+++ b/spec/content_block_tools/components/content_block_tools/tax_component_spec.rb
@@ -80,5 +80,53 @@ RSpec.describe ContentBlockTools::TaxComponent do
         end
       end
     end
+
+    describe "data validation for tax_table" do
+      let(:embed_code) { "{{embed:content_block_tax:income-tax#tax_table}}" }
+
+      context "when things_taxed is missing" do
+        let(:details) { { tax_type: "Tax" } }
+
+        it "raises InvalidFormatError with descriptive message" do
+          expect { component }.to raise_error(
+            ContentBlockTools::InvalidFormatError,
+            "Cannot render 'tax_table' format: missing income tax rates",
+          )
+        end
+      end
+
+      context "when income is missing from things_taxed" do
+        let(:details) { { tax_type: "Tax", things_taxed: {} } }
+
+        it "raises InvalidFormatError with descriptive message" do
+          expect { component }.to raise_error(
+            ContentBlockTools::InvalidFormatError,
+            "Cannot render 'tax_table' format: missing income tax rates",
+          )
+        end
+      end
+
+      context "when rates is missing from income" do
+        let(:details) { { tax_type: "Tax", things_taxed: { income: { title: "Income" } } } }
+
+        it "raises InvalidFormatError with descriptive message" do
+          expect { component }.to raise_error(
+            ContentBlockTools::InvalidFormatError,
+            "Cannot render 'tax_table' format: missing income tax rates",
+          )
+        end
+      end
+
+      context "when rates is empty" do
+        let(:details) { { tax_type: "Tax", things_taxed: { income: { rates: [] } } } }
+
+        it "raises InvalidFormatError with descriptive message" do
+          expect { component }.to raise_error(
+            ContentBlockTools::InvalidFormatError,
+            "Cannot render 'tax_table' format: missing income tax rates",
+          )
+        end
+      end
+    end
   end
 end

--- a/spec/content_block_tools/components/content_block_tools/tax_component_spec.rb
+++ b/spec/content_block_tools/components/content_block_tools/tax_component_spec.rb
@@ -34,10 +34,43 @@ RSpec.describe ContentBlockTools::TaxComponent do
                   },
                 ],
               },
+              {
+                name: "Basic rate",
+                value: "20%",
+                bands: [
+                  {
+                    name: "Basic rate",
+                    lower_threshold: { show: true, value: "£12,571" },
+                    upper_threshold: { show: true, value: "£50,270" },
+                  },
+                ],
+              },
             ],
           },
         },
       }
+    end
+
+    describe "rendering with tax_table format" do
+      let(:embed_code) { "{{embed:content_block_tax:income-tax#tax_table}}" }
+
+      it "renders a table" do
+        expect(component.render).to have_tag("table", with: { class: "govuk-table" })
+      end
+
+      it "renders table headers" do
+        rendered = component.render
+        expect(rendered).to have_tag("th", text: "Band")
+        expect(rendered).to have_tag("th", text: "Taxable income")
+        expect(rendered).to have_tag("th", text: "Tax rate")
+      end
+
+      it "renders the income tax rates as rows" do
+        rendered = component.render
+        expect(rendered).to have_tag("td", text: "Personal Allowance")
+        expect(rendered).to have_tag("td", text: "Up to £12,570")
+        expect(rendered).to have_tag("td", text: "0%")
+      end
     end
 
     describe "format validation" do
@@ -46,10 +79,6 @@ RSpec.describe ContentBlockTools::TaxComponent do
 
         it "does not raise an error" do
           expect { component }.not_to raise_error
-        end
-
-        it "returns a string from render" do
-          expect(component.render).to be_a(String)
         end
       end
 

--- a/spec/content_block_tools/components/content_block_tools/tax_component_spec.rb
+++ b/spec/content_block_tools/components/content_block_tools/tax_component_spec.rb
@@ -1,0 +1,84 @@
+RSpec.describe ContentBlockTools::TaxComponent do
+  describe "#render" do
+    let(:content_id) { SecureRandom.uuid }
+    let(:embed_code) { "{{embed:content_block_tax:income-tax#tax_table}}" }
+
+    let(:content_block) do
+      ContentBlockTools::ContentBlock.new(
+        document_type: "content_block_tax",
+        content_id:,
+        title: "Income Tax",
+        details: details,
+        embed_code: embed_code,
+      )
+    end
+
+    let(:component) { described_class.new(content_block:) }
+
+    let(:details) do
+      {
+        tax_type: "Tax",
+        things_taxed: {
+          income: {
+            title: "Income",
+            type: "Income",
+            rates: [
+              {
+                name: "Zero rate",
+                value: "0%",
+                bands: [
+                  {
+                    name: "Personal Allowance",
+                    lower_threshold: { show: true, value: "£0" },
+                    upper_threshold: { show: true, value: "£12,570" },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      }
+    end
+
+    describe "format validation" do
+      context "with tax_table format" do
+        let(:embed_code) { "{{embed:content_block_tax:income-tax#tax_table}}" }
+
+        it "does not raise an error" do
+          expect { component }.not_to raise_error
+        end
+
+        it "returns a string from render" do
+          expect(component.render).to be_a(String)
+        end
+      end
+
+      context "with default format" do
+        let(:embed_code) { "{{embed:content_block_tax:income-tax#default}}" }
+
+        it "does not raise an error" do
+          expect { component }.not_to raise_error
+        end
+      end
+
+      context "with no format specified" do
+        let(:embed_code) { "{{embed:content_block_tax:income-tax}}" }
+
+        it "does not raise an error" do
+          expect { component }.not_to raise_error
+        end
+      end
+
+      context "with an unsupported format" do
+        let(:embed_code) { "{{embed:content_block_tax:income-tax#unknown_format}}" }
+
+        it "raises InvalidFormatError" do
+          expect { component }.to raise_error(
+            ContentBlockTools::InvalidFormatError,
+            "Unknown format 'unknown_format' for tax",
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
See Jira [CM-932](https://gov-uk.atlassian.net/browse/CM-932):

---
## User story

- So that an editor can easily embed a table of tax rates and bands
- As a content editor
- I want to embed a tax table with a single embed code using a format

---

This PR introduces a `tax_table` "format" for use with a tax block.  Given an embed code for a tax block which includes the format e.g.

```
{{embed:content_block_tax:income-tax#tax_table}}
```

It renders a table in which 12 values from the tax block are organised into a table which corresponds to the table used in https://www.gov.uk/income-tax-rates

```

| Band               | Taxable income      | Tax rate |
| ------------------ | ------------------- | -------- |
| Personal Allowance | Up to £12,570       | 0%       |
| Basic rate         | £12,571 to £50,270  | 20%      |
| Higher rate        | £50,271 to £125,140 | 40%      |
| Additional rate    | over £125,140       | 45%      |

```



## Format rendered in Content Block Manager


<img width="798" height="1046" alt="generic_tax_table" src="https://github.com/user-attachments/assets/cb3b2b44-b710-484c-92a4-d47342dbc4e3" />


[CM-932]: https://gov-uk.atlassian.net/browse/CM-932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ