### PR TITLE
CM-933 Experiment: add "one off arrears format" for pension

### DIFF
--- a/app/components/content_block_tools/pension/one_off_arrears_component.html.erb
+++ b/app/components/content_block_tools/pension/one_off_arrears_component.html.erb
@@ -1,0 +1,5 @@
+<div>
+  <% paragraphs.each do |paragraph| %>
+    <p><%= paragraph.html_safe %></p>
+  <% end %>
+</div>

--- a/app/components/content_block_tools/pension/one_off_arrears_component.rb
+++ b/app/components/content_block_tools/pension/one_off_arrears_component.rb
@@ -1,0 +1,39 @@
+module ContentBlockTools
+  module Pension
+    class OneOffArrearsComponent < ContentBlockTools::BaseComponent
+      DEFERRAL_PERIODS = [52, 27].freeze
+      STATE_PENSION_URL = "/new-state-pension".freeze
+      STATE_PENSION_LINK_TEXT = "full new State Pension".freeze
+
+      def initialize(amount:)
+        @weekly_amount = amount
+      end
+
+      def render
+        render_in(view_context)
+      end
+
+    private
+
+      attr_reader :weekly_amount
+
+      def paragraphs
+        DEFERRAL_PERIODS.map { |weeks| arrears_paragraph(weeks) }
+      end
+
+      def arrears_paragraph(weeks)
+        arrears = format_currency(weekly_amount * weeks)
+        "If you defer your #{state_pension_link} for #{weeks} weeks, " \
+        "you'll get a one-off arrears payment of #{arrears}."
+      end
+
+      def state_pension_link
+        %(<a href="#{STATE_PENSION_URL}">#{STATE_PENSION_LINK_TEXT}</a>)
+      end
+
+      def format_currency(amount)
+        view_context.number_to_currency(amount, unit: "£", precision: 2)
+      end
+    end
+  end
+end

--- a/app/components/content_block_tools/pension_component.rb
+++ b/app/components/content_block_tools/pension_component.rb
@@ -5,6 +5,8 @@ module ContentBlockTools
       one_off_arrears
     ].freeze
 
+    CURRENCY_REGEX = /\A£?[\d,]+(?:\.\d{1,2})?\z/
+
     def initialize(content_block:, _block_type: nil, _block_name: nil)
       @content_block = content_block
       validate_format!
@@ -35,11 +37,45 @@ module ContentBlockTools
               "Cannot render 'one_off_arrears' format: no rates found"
       end
 
-      return unless rates.size > 1
+      if rates.size > 1
+        raise InvalidFormatError,
+              "Cannot render 'one_off_arrears' format: " \
+              "expected exactly one rate, found #{rates.size}"
+      end
+
+      validate_amount!
+    end
+
+    def validate_amount!
+      amount_string = single_rate[:amount]
+
+      if amount_string.nil? || amount_string.to_s.strip.empty?
+        raise InvalidFormatError,
+              "Cannot render 'one_off_arrears' format: rate is missing 'amount'"
+      end
+
+      unless parseable_currency?(amount_string)
+        raise InvalidFormatError,
+              "Cannot render 'one_off_arrears' format: " \
+              "'#{amount_string}' is not a valid currency amount"
+      end
+
+      return unless parse_currency(amount_string) <= 0
 
       raise InvalidFormatError,
-            "Cannot render 'one_off_arrears' format: " \
-            "expected exactly one rate, found #{rates.size}"
+            "Cannot render 'one_off_arrears' format: amount must be positive"
+    end
+
+    def single_rate
+      details[:rates].values.first
+    end
+
+    def parseable_currency?(string)
+      CURRENCY_REGEX.match?(string.to_s.strip)
+    end
+
+    def parse_currency(string)
+      BigDecimal(string.to_s.gsub(/[£,]/, ""))
     end
 
     def one_off_arrears_format?

--- a/app/components/content_block_tools/pension_component.rb
+++ b/app/components/content_block_tools/pension_component.rb
@@ -1,0 +1,29 @@
+module ContentBlockTools
+  class PensionComponent < ContentBlockTools::BaseComponent
+    SUPPORTED_FORMATS = %w[
+      default
+      one_off_arrears
+    ].freeze
+
+    def initialize(content_block:, _block_type: nil, _block_name: nil)
+      @content_block = content_block
+      validate_format!
+    end
+
+    def render
+      ""
+    end
+
+  private
+
+    attr_reader :content_block
+
+    delegate :format, :details, to: :content_block
+
+    def validate_format!
+      return if SUPPORTED_FORMATS.include?(format)
+
+      raise InvalidFormatError, "Unknown format '#{format}' for pension"
+    end
+  end
+end

--- a/app/components/content_block_tools/pension_component.rb
+++ b/app/components/content_block_tools/pension_component.rb
@@ -8,6 +8,7 @@ module ContentBlockTools
     def initialize(content_block:, _block_type: nil, _block_name: nil)
       @content_block = content_block
       validate_format!
+      validate_single_rate! if one_off_arrears_format?
     end
 
     def render
@@ -24,6 +25,25 @@ module ContentBlockTools
       return if SUPPORTED_FORMATS.include?(format)
 
       raise InvalidFormatError, "Unknown format '#{format}' for pension"
+    end
+
+    def validate_single_rate!
+      rates = details[:rates]
+
+      unless rates.present?
+        raise InvalidFormatError,
+              "Cannot render 'one_off_arrears' format: no rates found"
+      end
+
+      return unless rates.size > 1
+
+      raise InvalidFormatError,
+            "Cannot render 'one_off_arrears' format: " \
+            "expected exactly one rate, found #{rates.size}"
+    end
+
+    def one_off_arrears_format?
+      format == "one_off_arrears"
     end
   end
 end

--- a/app/components/content_block_tools/pension_component.rb
+++ b/app/components/content_block_tools/pension_component.rb
@@ -14,7 +14,9 @@ module ContentBlockTools
     end
 
     def render
-      ""
+      return "" unless one_off_arrears_format?
+
+      Pension::OneOffArrearsComponent.new(amount: weekly_amount).render
     end
 
   private
@@ -68,6 +70,10 @@ module ContentBlockTools
 
     def single_rate
       details[:rates].values.first
+    end
+
+    def weekly_amount
+      parse_currency(single_rate[:amount])
     end
 
     def parseable_currency?(string)

--- a/content_block_tools.gemspec
+++ b/content_block_tools.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]
 
+  spec.add_development_dependency "capybara"
   spec.add_development_dependency "cucumber", "~> 11.0"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake", "13.4.2"

--- a/features/pension_rendering.feature
+++ b/features/pension_rendering.feature
@@ -1,0 +1,26 @@
+Feature: Pension rendering
+  So that users can understand pension deferral arrears
+  As a content editor
+  I want pension blocks to render with arrears calculations
+
+  Scenario: Render one_off_arrears format
+    Given a pension content block with weekly rate "£241.30"
+    When asked to render pension with embed code "{{embed:content_block_pension:state-pension#one_off_arrears}}"
+    Then the rendered output should contain "one-off arrears payment of £12,547.60"
+    And the rendered output should contain "one-off arrears payment of £6,515.10"
+    And the rendered output should contain a link to "/new-state-pension"
+
+  Scenario: Raise error for unknown format
+    Given a pension content block with weekly rate "£241.30"
+    When asked to render pension with embed code "{{embed:content_block_pension:state-pension#unknown_format}}"
+    Then an InvalidFormatError should be raised with message "Unknown format 'unknown_format' for pension"
+
+  Scenario: Raise error for zero rates
+    Given a pension content block with no rates
+    When asked to render pension with embed code "{{embed:content_block_pension:state-pension#one_off_arrears}}"
+    Then an InvalidFormatError should be raised with message "Cannot render 'one_off_arrears' format: no rates found"
+
+  Scenario: Raise error for multiple rates
+    Given a pension content block with multiple rates
+    When asked to render pension with embed code "{{embed:content_block_pension:state-pension#one_off_arrears}}"
+    Then an InvalidFormatError should be raised with message "Cannot render 'one_off_arrears' format: expected exactly one rate, found 2"

--- a/features/step_definitions/pension_steps.rb
+++ b/features/step_definitions/pension_steps.rb
@@ -1,0 +1,62 @@
+Given("a pension content block with weekly rate {string}") do |amount|
+  @content_block_details = {
+    rates: {
+      "weekly-rate": {
+        title: "Weekly rate",
+        amount: amount,
+        frequency: "a week",
+      },
+    },
+  }
+end
+
+Given("a pension content block with no rates") do
+  @content_block_details = {
+    rates: {},
+  }
+end
+
+Given("a pension content block with multiple rates") do
+  @content_block_details = {
+    rates: {
+      "rate-one": {
+        title: "Rate one",
+        amount: "£100.00",
+        frequency: "a week",
+      },
+      "rate-two": {
+        title: "Rate two",
+        amount: "£200.00",
+        frequency: "a week",
+      },
+    },
+  }
+end
+
+When("asked to render pension with embed code {string}") do |embed_code|
+  @content_block = ContentBlockTools::ContentBlock.new(
+    document_type: "content_block_pension",
+    content_id: SecureRandom.uuid,
+    title: "State Pension",
+    details: @content_block_details,
+    embed_code:,
+  )
+
+  begin
+    @rendered = @content_block.render
+    @error = nil
+  rescue ContentBlockTools::InvalidFormatError => e
+    @error = e
+    @rendered = nil
+  end
+end
+
+Then("the rendered output should contain {string}") do |expected_text|
+  expect(@error).to be_nil, "Expected no error but got: #{@error&.message}"
+  expect(@rendered).to include(expected_text)
+end
+
+Then("the rendered output should contain a link to {string}") do |href|
+  expect(@error).to be_nil, "Expected no error but got: #{@error&.message}"
+  expect(@rendered).to have_tag("a", with: { href: href })
+end

--- a/spec/content_block_tools/components/content_block_tools/pension/one_off_arrears_component_spec.rb
+++ b/spec/content_block_tools/components/content_block_tools/pension/one_off_arrears_component_spec.rb
@@ -1,0 +1,85 @@
+RSpec.describe ContentBlockTools::Pension::OneOffArrearsComponent do
+  describe "#render" do
+    let(:component) { described_class.new(amount:) }
+    let(:amount) { BigDecimal("241.30") }
+    let(:html) { Capybara.string(component.render) }
+
+    it "renders a containing div" do
+      expect(html).to have_css("div")
+    end
+
+    it "renders two paragraphs" do
+      expect(html).to have_css("div > p", count: 2)
+    end
+
+    describe "first paragraph (52 weeks deferral)" do
+      let(:first_paragraph) { html.first("p") }
+
+      it "mentions 52 weeks deferral" do
+        expect(first_paragraph).to have_text("for 52 weeks")
+      end
+
+      it "calculates arrears correctly (£241.30 × 52 = £12,547.60)" do
+        expect(first_paragraph).to have_text("one-off arrears payment of £12,547.60")
+      end
+
+      it "includes a link to the new state pension page" do
+        expect(first_paragraph).to have_css(
+          "a[href='/new-state-pension']",
+          text: "full new State Pension",
+        )
+      end
+    end
+
+    describe "second paragraph (27 weeks deferral)" do
+      let(:second_paragraph) { html.all("p").last }
+
+      it "mentions 27 weeks deferral" do
+        expect(second_paragraph).to have_text("for 27 weeks")
+      end
+
+      it "calculates arrears correctly (£241.30 × 27 = £6,515.10)" do
+        expect(second_paragraph).to have_text("one-off arrears payment of £6,515.10")
+      end
+
+      it "includes a link to the new state pension page" do
+        expect(second_paragraph).to have_css(
+          "a[href='/new-state-pension']",
+          text: "full new State Pension",
+        )
+      end
+    end
+
+    describe "currency formatting" do
+      context "with an amount requiring thousand separators" do
+        let(:amount) { BigDecimal("1000.00") }
+
+        it "formats 52-week arrears with commas (£1000 × 52 = £52,000.00)" do
+          expect(html.first("p")).to have_text("£52,000.00")
+        end
+
+        it "formats 27-week arrears with commas (£1000 × 27 = £27,000.00)" do
+          expect(html.all("p").last).to have_text("£27,000.00")
+        end
+      end
+
+      context "with a small amount" do
+        let(:amount) { BigDecimal("10.00") }
+
+        it "formats without thousand separators" do
+          expect(html.first("p")).to have_text("£520.00")
+          expect(html.all("p").last).to have_text("£270.00")
+        end
+      end
+
+      context "with a precise decimal amount" do
+        let(:amount) { BigDecimal("100.50") }
+
+        it "maintains two decimal places" do
+          expect(html.first("p")).to have_text("£5,226.00")
+          expect(html.all("p").last).to have_text("£2,713.50")
+        end
+      end
+    end
+  end
+end

--- a/spec/content_block_tools/components/content_block_tools/pension_component_spec.rb
+++ b/spec/content_block_tools/components/content_block_tools/pension_component_spec.rb
@@ -1,0 +1,71 @@
+RSpec.describe ContentBlockTools::PensionComponent do
+  describe "#render" do
+    let(:content_id) { SecureRandom.uuid }
+    let(:embed_code) { "{{embed:content_block_pension:state-pension}}" }
+
+    let(:content_block) do
+      ContentBlockTools::ContentBlock.new(
+        document_type: "content_block_pension",
+        content_id:,
+        title: "State Pension",
+        details: details,
+        embed_code: embed_code,
+      )
+    end
+
+    let(:component) { described_class.new(content_block:) }
+
+    let(:details) do
+      {
+        rates: {
+          "weekly-rate": {
+            title: "Weekly rate",
+            amount: "£241.30",
+            frequency: "a week",
+          },
+        },
+      }
+    end
+
+    describe "format validation" do
+      context "with default format" do
+        let(:embed_code) { "{{embed:content_block_pension:state-pension}}" }
+
+        it "does not raise an error" do
+          expect { component }.not_to raise_error
+        end
+
+        it "returns an empty string" do
+          expect(component.render).to eq("")
+        end
+      end
+
+      context "with explicit default format" do
+        let(:embed_code) { "{{embed:content_block_pension:state-pension#default}}" }
+
+        it "does not raise an error" do
+          expect { component }.not_to raise_error
+        end
+      end
+
+      context "with one_off_arrears format" do
+        let(:embed_code) { "{{embed:content_block_pension:state-pension#one_off_arrears}}" }
+
+        it "does not raise an error" do
+          expect { component }.not_to raise_error
+        end
+      end
+
+      context "with an unsupported format" do
+        let(:embed_code) { "{{embed:content_block_pension:state-pension#unknown_format}}" }
+
+        it "raises InvalidFormatError" do
+          expect { component }.to raise_error(
+            ContentBlockTools::InvalidFormatError,
+            "Unknown format 'unknown_format' for pension",
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/content_block_tools/components/content_block_tools/pension_component_spec.rb
+++ b/spec/content_block_tools/components/content_block_tools/pension_component_spec.rb
@@ -67,5 +67,55 @@ RSpec.describe ContentBlockTools::PensionComponent do
         end
       end
     end
+
+    describe "rate validation for one_off_arrears" do
+      let(:embed_code) { "{{embed:content_block_pension:state-pension#one_off_arrears}}" }
+
+      context "when there is exactly one rate" do
+        it "does not raise an error" do
+          expect { component }.not_to raise_error
+        end
+      end
+
+      context "when there is no rates key" do
+        let(:details) { {} }
+
+        it "raises InvalidFormatError" do
+          expect { component }.to raise_error(
+            ContentBlockTools::InvalidFormatError,
+            "Cannot render 'one_off_arrears' format: no rates found",
+          )
+        end
+      end
+
+      context "when the rates collection is empty" do
+        let(:details) { { rates: {} } }
+
+        it "raises InvalidFormatError" do
+          expect { component }.to raise_error(
+            ContentBlockTools::InvalidFormatError,
+            "Cannot render 'one_off_arrears' format: no rates found",
+          )
+        end
+      end
+
+      context "when there are multiple rates" do
+        let(:details) do
+          {
+            rates: {
+              "rate-one": { title: "Rate one", amount: "£100.00" },
+              "rate-two": { title: "Rate two", amount: "£200.00" },
+            },
+          }
+        end
+
+        it "raises InvalidFormatError" do
+          expect { component }.to raise_error(
+            ContentBlockTools::InvalidFormatError,
+            "Cannot render 'one_off_arrears' format: expected exactly one rate, found 2",
+          )
+        end
+      end
+    end
   end
 end

--- a/spec/content_block_tools/components/content_block_tools/pension_component_spec.rb
+++ b/spec/content_block_tools/components/content_block_tools/pension_component_spec.rb
@@ -117,5 +117,97 @@ RSpec.describe ContentBlockTools::PensionComponent do
         end
       end
     end
+
+    describe "amount validation for one_off_arrears" do
+      let(:embed_code) { "{{embed:content_block_pension:state-pension#one_off_arrears}}" }
+
+      context "with a valid amount" do
+        it "does not raise an error" do
+          expect { component }.not_to raise_error
+        end
+      end
+
+      context "with amount without currency symbol" do
+        let(:details) { { rates: { "rate": { amount: "241.30" } } } }
+
+        it "does not raise an error" do
+          expect { component }.not_to raise_error
+        end
+      end
+
+      context "with amount with commas" do
+        let(:details) { { rates: { "rate": { amount: "£1,241.30" } } } }
+
+        it "does not raise an error" do
+          expect { component }.not_to raise_error
+        end
+      end
+
+      context "with missing amount" do
+        let(:details) { { rates: { "rate": { title: "Rate" } } } }
+
+        it "raises InvalidFormatError" do
+          expect { component }.to raise_error(
+            ContentBlockTools::InvalidFormatError,
+            "Cannot render 'one_off_arrears' format: rate is missing 'amount'",
+          )
+        end
+      end
+
+      context "with empty amount" do
+        let(:details) { { rates: { "rate": { amount: "" } } } }
+
+        it "raises InvalidFormatError" do
+          expect { component }.to raise_error(
+            ContentBlockTools::InvalidFormatError,
+            "Cannot render 'one_off_arrears' format: rate is missing 'amount'",
+          )
+        end
+      end
+
+      context "with whitespace-only amount" do
+        let(:details) { { rates: { "rate": { amount: "   " } } } }
+
+        it "raises InvalidFormatError" do
+          expect { component }.to raise_error(
+            ContentBlockTools::InvalidFormatError,
+            "Cannot render 'one_off_arrears' format: rate is missing 'amount'",
+          )
+        end
+      end
+
+      context "with invalid amount format" do
+        let(:details) { { rates: { "rate": { amount: "not a number" } } } }
+
+        it "raises InvalidFormatError" do
+          expect { component }.to raise_error(
+            ContentBlockTools::InvalidFormatError,
+            "Cannot render 'one_off_arrears' format: 'not a number' is not a valid currency amount",
+          )
+        end
+      end
+
+      context "with zero amount" do
+        let(:details) { { rates: { "rate": { amount: "£0.00" } } } }
+
+        it "raises InvalidFormatError" do
+          expect { component }.to raise_error(
+            ContentBlockTools::InvalidFormatError,
+            "Cannot render 'one_off_arrears' format: amount must be positive",
+          )
+        end
+      end
+
+      context "with negative amount" do
+        let(:details) { { rates: { "rate": { amount: "-£100.00" } } } }
+
+        it "raises InvalidFormatError" do
+          expect { component }.to raise_error(
+            ContentBlockTools::InvalidFormatError,
+            "Cannot render 'one_off_arrears' format: '-£100.00' is not a valid currency amount",
+          )
+        end
+      end
+    end
   end
 end

--- a/spec/content_block_tools/components/content_block_tools/pension_component_spec.rb
+++ b/spec/content_block_tools/components/content_block_tools/pension_component_spec.rb
@@ -209,5 +209,25 @@ RSpec.describe ContentBlockTools::PensionComponent do
         end
       end
     end
+
+    describe "rendering one_off_arrears format" do
+      let(:embed_code) { "{{embed:content_block_pension:state-pension#one_off_arrears}}" }
+
+      it "renders arrears paragraphs via OneOffArrearsComponent" do
+        rendered = component.render
+        expect(rendered).to include("one-off arrears payment of £12,547.60")
+        expect(rendered).to include("one-off arrears payment of £6,515.10")
+      end
+
+      it "includes a link to /new-state-pension" do
+        expect(component.render).to have_tag("a", with: { href: "/new-state-pension" })
+      end
+
+      it "renders within a div" do
+        expect(component.render).to have_tag("div") do
+          with_tag("p", count: 2)
+        end
+      end
+    end
   end
 end

--- a/spec/content_block_tools/content_block_spec.rb
+++ b/spec/content_block_tools/content_block_spec.rb
@@ -353,10 +353,10 @@ RSpec.describe ContentBlockTools::ContentBlock do
       end
 
       context "embed code does not include any field or block references" do
-        let(:embed_code) { "{{embed:content_block_contact:pension}}" }
+        let(:embed_code) { "{{embed:content_block_pension:state-pension}}" }
 
-        it "returns the content block's title" do
-          expect(content_block.render).to have_tag("div", text: content_block.title, with: expected_wrapper_attributes)
+        it "renders an empty div for default format" do
+          expect(content_block.render).to have_tag("div", text: "", with: expected_wrapper_attributes)
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ SimpleCov.start do
 end
 
 require "bundler/setup"
+require "capybara/rspec"
 require "securerandom"
 require "rspec-html-matchers"
 


### PR DESCRIPTION
See [Jira CM-933](https://gov-uk.atlassian.net/browse/CM-933)

In this PR we explore a format which presents a pension rate in an "example" of 27 and 52 week deferrals, as per:

https://www.gov.uk/deferring-state-pension/if-you-reach-state-pension-age-on-or-after-6-april-2016 

> Example
> 
> If you defer your [full new State Pension](https://www.gov.uk/new-state-pension) for 52 weeks, you’ll get a one-off arrears payment of £12,547.60.
> 
> If you defer your [full new State Pension](https://www.gov.uk/new-state-pension) for 27 weeks, you’ll get a one-off arrears payment of £6,515.10.

With this PR, this block of content can be rendered as a `format` of the new state pension block, with:

```
{{embed:content_block_pension:new_state_pension#one_off_arrears}}
```

We note that each paragraph includes a link to /new-state-pension -- probably this really
ought to be supplied by way of a `Contact#contact_link`, and it suggests
that perhaps there's another concept to be explored: that of composition.

Can we map out a future state where Content Block Manager offer editors a
facility to define their own composite blocks, combining:

- arbitrary free form copy e.g. "If you defer your"

- entire content blocks e.g. `{{embed:content_block_time_period:tax-year}}`

- formatted blocks e.g. `{{embed:content_block_time_period:tax-year#short}}`

- constituent content from blocks e.g.
  `{{embed:content_block_contact:pension-office/contact_links/new_state_pension}}`

all this via a GUI where the editor can browse and discover the content they
seek intuitively?

<img width="955" height="1425" alt="pension_one_off_arrears" src="https://github.com/user-attachments/assets/753233cd-686e-4a31-a492-3345d1133973" />

