### PR TITLE
(CM-926) Add a clear contact method ID to markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.12.2
+
+* Add data attributes to identify contact parts
+
 ## 1.12.1
 
 * Update dependencies

--- a/app/components/content_block_tools/contact_component.html.erb
+++ b/app/components/content_block_tools/contact_component.html.erb
@@ -1,13 +1,13 @@
 <div class="vcard">
   <% if block_type.nil? %>
     <% if content_block.details[:description] %>
-      <div data-diff-key="description">
+      <div data-diff-key="description" data-id="description">
         <%= render_govspeak(content_block.details[:description]) %>
       </div>
     <% end %>
     <dl class="<%= margin_classes(0) %> <%= padding_classes(0) %>">
       <% items.each do |block_type, key, item| %>
-        <div data-diff-key="<%= block_type %>-<%= key %>">
+        <div data-diff-key="<%= block_type %>-<%= key %>" data-block-type="<%= block_type %>" data-block-id="<%= key %>">
           <dt class="<%= margin_classes(0, 0, 4, 0) %> <%= padding_classes(0) %> <%= font_classes(19, "bold") %>">
             <%= item[:title] %>
           </dt>

--- a/features/step_definitions/contact_steps.rb
+++ b/features/step_definitions/contact_steps.rb
@@ -35,7 +35,7 @@ end
 Then("I should see the complete contact details within a vcard") do
   expect(@rendered).to have_tag("div.content-block.content-block--contact") do
     with_tag("div.vcard") do
-      with_tag "div", with: { "data-diff-key" => "email_addresses-main" } do
+      with_tag "div", with: { "data-block-type" => "email_addresses", "data-block-id" => "main" } do
         with_tag("dt", seen: "Email")
         with_tag(
           "a",
@@ -44,12 +44,12 @@ Then("I should see the complete contact details within a vcard") do
         )
       end
 
-      with_tag "div", with: { "data-diff-key" => "telephones-main" } do
+      with_tag "div", with: { "data-block-type" => "telephones", "data-block-id" => "main" } do
         with_tag("dt", seen: "Phone")
         with_tag("dd", seen: "Telephone: 020 7946 0958")
       end
 
-      with_tag "div", with: { "data-diff-key" => "addresses-main" } do
+      with_tag "div", with: { "data-block-type" => "addresses", "data-block-id" => "main" } do
         with_tag("dt", seen: "Address")
         with_tag("dd", seen: "10 Downing St, London")
       end

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "1.12.1"
+  VERSION = "1.12.2"
 end

--- a/spec/content_block_tools/components/content_block_tools/contact_component_spec.rb
+++ b/spec/content_block_tools/components/content_block_tools/contact_component_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe ContentBlockTools::ContactComponent do
                              .and_call_original
 
       expect(component.render).to have_tag("div", with: { class: "vcard" }) do
-        with_tag("div", with: { "data-diff-key" => "description" }) do
+        with_tag("div", with: { "data-id" => "description" }) do
           with_tag("p", text: description)
         end
       end
@@ -169,7 +169,7 @@ RSpec.describe ContentBlockTools::ContactComponent do
 
       expect(component.render).to have_tag("div", with: { class: "vcard" }) do
         with_tag("dl") do
-          with_tag("div", with: { "data-diff-key" => "email_addresses-foo" }) do
+          with_tag("div", with: { "data-block-type" => "email_addresses", "data-block-id" => "foo" }) do
             with_tag("dt", text: /#{email_addresses[:foo][:title]}/)
             with_tag("dd") do
               with_tag("p", text: "EMAIL ADDRESS")
@@ -184,7 +184,7 @@ RSpec.describe ContentBlockTools::ContactComponent do
 
       expect(component.render).to have_tag("div", with: { class: "vcard" }) do
         without_tag("dl")
-        without_tag("div", with: { "data-diff-key" => "email_addresses-foo" })
+        without_tag("div", with: { "data-block-type" => "email_addresses", "data-block-id" => "foo" })
         without_tag("dt", text: email_addresses[:foo][:title])
         with_tag("p", text: "EMAIL ADDRESS")
       end
@@ -217,7 +217,7 @@ RSpec.describe ContentBlockTools::ContactComponent do
 
       expect(component.render).to have_tag("div", with: { class: "vcard" }) do
         with_tag("dl") do
-          with_tag("div", with: { "data-diff-key" => "telephones-foo" }) do
+          with_tag("div", with: { "data-block-type" => "telephones", "data-block-id" => "foo" }) do
             with_tag("dt", text: /#{telephones[:foo][:title]}/)
             with_tag("dd") do
               with_tag("p", text: "TELEPHONE")
@@ -232,7 +232,7 @@ RSpec.describe ContentBlockTools::ContactComponent do
 
       expect(component.render).to have_tag("div", with: { class: "vcard" }) do
         without_tag("dl")
-        without_tag("div", with: { "data-diff-key" => "telephones-foo" })
+        without_tag("div", with: { "data-block-type" => "telephones", "data-block-id" => "foo" })
         without_tag("dt", text: telephones[:foo][:title])
         with_tag("p", text: "TELEPHONE")
       end
@@ -265,7 +265,7 @@ RSpec.describe ContentBlockTools::ContactComponent do
 
       expect(component.render).to have_tag("div", with: { class: "vcard" }) do
         with_tag("dl") do
-          with_tag("div", with: { "data-diff-key" => "addresses-some_address" }) do
+          with_tag("div", with: { "data-block-type" => "addresses", "data-block-id" => "some_address" }) do
             with_tag("dt", text: /#{addresses[:some_address][:title]}/)
             with_tag("dd") do
               with_tag("p", text: "ADDRESS")
@@ -280,7 +280,7 @@ RSpec.describe ContentBlockTools::ContactComponent do
 
       expect(component.render).to have_tag("div", with: { class: "vcard" }) do
         without_tag("dl")
-        without_tag("div", with: { "data-diff-key" => "addresses-some_address" })
+        without_tag("div", with: { "data-block-type" => "addresses", "data-block-id" => "some_address" })
         without_tag("dt", text: /#{addresses[:some_address][:title]}/)
         with_tag("p", text: "ADDRESS")
       end
@@ -313,7 +313,7 @@ RSpec.describe ContentBlockTools::ContactComponent do
 
       expect(component.render).to have_tag("div", with: { class: "vcard" }) do
         with_tag("dl") do
-          with_tag("div", with: { "data-diff-key" => "contact_links-foo" }) do
+          with_tag("div", with: { "data-block-type" => "contact_links", "data-block-id" => "foo" }) do
             with_tag("dt", text: /#{contact_links[:foo][:title]}/)
             with_tag("dd") do
               with_tag("p", text: "CONTACT LINK")
@@ -328,7 +328,7 @@ RSpec.describe ContentBlockTools::ContactComponent do
 
       expect(component.render).to have_tag("div", with: { class: "vcard" }) do
         without_tag("dl")
-        without_tag("div", with: { "data-diff-key" => "contact_links-foo" })
+        without_tag("div", with: { "data-block-type" => "contact_links", "data-block-id" => "foo" })
         without_tag("dt", text: /#{contact_links[:foo][:title]}/)
         with_tag("p", text: "CONTACT LINK")
       end


### PR DESCRIPTION
Before, we were using `data-diff-key` to identify the parts in tests, this is OK, but it:

* is obscure as it clear is part of the diffing mechanism rather than being a general purpose and semantic ID
* can’t be counted on to persist as is liable to change as the needs and implementation of the diffing tool (Nokodiff) develop