### PR TITLE
CM-944: Add pension rate presenter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 1.14.0
+
+* Add dual-format support for `Pension#amount` - accepts both legacy 
+  format (string including '£' prefix) and new string format without '£' prefix
+
 # 11.13.0
 
 * Add "tax_table" format rendering for tax blocks [#155](https://github.com/alphagov/govuk_content_block_tools/pull/155)

--- a/features/pension_amount_rendering.feature
+++ b/features/pension_amount_rendering.feature
@@ -1,0 +1,24 @@
+Feature: Pension amount rendering
+  So that users can easily identify and use pension information
+  As a content editor
+  I want the pension rate to render with a £ prefix
+
+Scenario: Pension amount renders with £ prefix when provided in the data
+    Given a pension content block with the following details:
+      | field       | value                    |
+      | title       | 2026 state pension       |
+      | amount      | £436.88                  |
+      | frequency   | weekly                   |
+      | description | The new pension rate     |
+    When I render the content block
+    Then the rendered output should be "£436.88"
+
+Scenario: Pension amount renders with £ prefix when not provided in the data
+    Given a pension content block with the following details:
+      | field       | value                    |
+      | title       | 2026 state pension       |
+      | amount      | 436.88                   |
+      | frequency   | weekly                   |
+      | description | The new pension rate     |
+    When I render the content block
+    Then the rendered output should be "£436.88"

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -1,3 +1,8 @@
 When("I render the content block") do
   @rendered = @content_block.render
 end
+
+Then("the rendered output should be {string}") do |expected_text|
+  expect(@error).to be_nil, "Expected no error but got: #{@error&.message}"
+  expect(@rendered).to include(expected_text)
+end

--- a/features/step_definitions/pension_steps.rb
+++ b/features/step_definitions/pension_steps.rb
@@ -1,0 +1,21 @@
+Given("a pension content block with the following details:") do |table|
+  details = table.rows_hash.transform_keys(&:to_sym)
+
+  @content_block = ContentBlockTools::ContentBlock.new(
+    document_type: "content_block_pension",
+    content_id: SecureRandom.uuid,
+    title: "Test Pension",
+    details: {
+      "description" => "The new pension rate",
+      "rates" => {
+        "full-basic-state-pension" => {
+          "title" => details[:title],
+          "amount" => details[:amount],
+          "frequency" => details[:frequency],
+          "description" => details[:description],
+        },
+      },
+    },
+    embed_code: "{{embed:content_block_pension:test-pension/rates/full-basic-state-pension/amount}}",
+  )
+end

--- a/features/step_definitions/time_period_steps.rb
+++ b/features/step_definitions/time_period_steps.rb
@@ -27,11 +27,6 @@ When("asked to render with embed code {string}") do |embed_code|
   end
 end
 
-Then("the rendered output should be {string}") do |expected_text|
-  expect(@error).to be_nil, "Expected no error but got: #{@error&.message}"
-  expect(@rendered).to include(expected_text)
-end
-
 Then("an InvalidFormatError should be raised with message {string}") do |expected_message|
   expect(@error).to be_a(ContentBlockTools::InvalidFormatError)
   expect(@error.message).to eq(expected_message)

--- a/lib/content_block_tools.rb
+++ b/lib/content_block_tools.rb
@@ -15,6 +15,7 @@ require "content_block_tools/presenters/field_presenters/time_period/date_presen
 require "content_block_tools/presenters/field_presenters/time_period/time_presenter"
 require "content_block_tools/presenters/field_presenters/time_period/start_presenter"
 require "content_block_tools/presenters/field_presenters/time_period/end_presenter"
+require "content_block_tools/presenters/field_presenters/pension/amount_presenter"
 
 require "content_block_tools/content_block"
 require "content_block_tools/content_block_reference"

--- a/lib/content_block_tools/presenters/field_presenters/pension/amount_presenter.rb
+++ b/lib/content_block_tools/presenters/field_presenters/pension/amount_presenter.rb
@@ -1,0 +1,13 @@
+module ContentBlockTools
+  module Presenters
+    module FieldPresenters
+      module Pension
+        class AmountPresenter < BasePresenter
+          def render
+            field.start_with?("£") ? field : "£#{field}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/content_block_tools/presenters/field_presenters/pension/amount_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/field_presenters/pension/amount_presenter_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe ContentBlockTools::Presenters::FieldPresenters::Pension::AmountPresenter do
+  context "when the given param is a string representation of a pension rate without a £ prefix" do
+    it "presents the rate with a £ prefix" do
+      presenter = described_class.new("100.30")
+
+      expect(presenter.render).to eq("£100.30")
+    end
+  end
+
+  context "when the given param is a string representation of a pension rate with a £ prefix" do
+    it "presents the rate without adding an additional £ prefix" do
+      presenter = described_class.new("£100.30")
+
+      expect(presenter.render).to eq("£100.30")
+    end
+  end
+end


### PR DESCRIPTION
Jira ticket: https://gov-uk.atlassian.net/browse/CM-944

We are changing our pension model so that the ‘£’ prefix is not included in the pension rate string. Adding this presenter which covers both possible cases (with and without the prefix) gives us confidence that the change will not cause disruption to our users.

Once the change to our model is complete and we have migrated existing values so that they do not include the prefix, we will update the presenter to only account for the “no prefix” case.

This repo is owned by the content modelling team. Please let us know in #govuk-publishing-content-modelling-dev when you raise any PRs.