### PR TITLE
Bump version to 1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Add dual-format support for `Pension#amount` - accepts both legacy 
   format (string including '£' prefix) and new string format without '£' prefix
 
-# 11.13.0
+# 1.13.0
 
 * Add "tax_table" format rendering for tax blocks [#155](https://github.com/alphagov/govuk_content_block_tools/pull/155)
 

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "1.13.0"
+  VERSION = "1.14.0"
 end


### PR DESCRIPTION
When I rebased my changes this morning, I updated the CHANGELOG, but left this file as it was. This corrects that and updates the version to 1.14.0

This repo is owned by the content modelling team. Please let us know in #govuk-publishing-content-modelling-dev when you raise any PRs.
