### PR TITLE
Remove support for pension amount with prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,20 @@ content_block.render
 
 For more information, see the [Documentation](https://www.rubydoc.info/github/alphagov/content_block_tools)
 
+## Development
+
+### Running the test suites
+
+To run the unit tests:
+```
+bundle exec rspec
+```
+
+To run the feature tests:
+```
+bundle exec cucumber
+```
+
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/features/pension_amount_rendering.feature
+++ b/features/pension_amount_rendering.feature
@@ -3,17 +3,7 @@ Feature: Pension amount rendering
   As a content editor
   I want the pension rate to render with a £ prefix
 
-Scenario: Pension amount renders with £ prefix when provided in the data
-    Given a pension content block with the following details:
-      | field       | value                    |
-      | title       | 2026 state pension       |
-      | amount      | £436.88                  |
-      | frequency   | weekly                   |
-      | description | The new pension rate     |
-    When I render the content block
-    Then the rendered output should be "£436.88"
-
-Scenario: Pension amount renders with £ prefix when not provided in the data
+Scenario: Pension amount renders with £ prefix
     Given a pension content block with the following details:
       | field       | value                    |
       | title       | 2026 state pension       |

--- a/lib/content_block_tools/presenters/field_presenters/pension/amount_presenter.rb
+++ b/lib/content_block_tools/presenters/field_presenters/pension/amount_presenter.rb
@@ -4,7 +4,7 @@ module ContentBlockTools
       module Pension
         class AmountPresenter < BasePresenter
           def render
-            field.start_with?("£") ? field : "£#{field}"
+            "£#{field}"
           end
         end
       end

--- a/spec/content_block_tools/presenters/field_presenters/pension/amount_presenter_spec.rb
+++ b/spec/content_block_tools/presenters/field_presenters/pension/amount_presenter_spec.rb
@@ -6,12 +6,4 @@ RSpec.describe ContentBlockTools::Presenters::FieldPresenters::Pension::AmountPr
       expect(presenter.render).to eq("£100.30")
     end
   end
-
-  context "when the given param is a string representation of a pension rate with a £ prefix" do
-    it "presents the rate without adding an additional £ prefix" do
-      presenter = described_class.new("£100.30")
-
-      expect(presenter.render).to eq("£100.30")
-    end
-  end
 end


### PR DESCRIPTION
Whilst we were in the process of rolling out changes to the pension amount field (removing the currency prefix from within the string value), we introduced this presenter to ensure backwards compatibility. The changes are now rolled out and so we can remove the support for the legacy data structure.