### PR TITLE
Update comments with outdated embed code notation

### DIFF
--- a/lib/content_block_tools/embed_code.rb
+++ b/lib/content_block_tools/embed_code.rb
@@ -5,8 +5,8 @@ module ContentBlockTools
   # fields to render. The format is:
   #   {{embed:block_type:identifier}}
   #   {{embed:block_type:identifier/field1/nested_field2}}
-  #   {{embed:block_type:identifier|format}}
-  #   {{embed:block_type:identifier/field1|format}}
+  #   {{embed:block_type:identifier#format}}
+  #   {{embed:block_type:identifier/field1#format}}
   #
   # @example Basic embed code
   #   embed_code = EmbedCode.new("{{embed:content_block_contact:main-office}}")


### PR DESCRIPTION
Some comments still referenced the older style we had used for denoting a 'format' in an embed code using a pipe symbol `|`. This updates the comments to use the correct notation. The code itself seems to be correct.

This repo is owned by the content modelling team. Please let us know in #govuk-publishing-content-modelling-dev when you raise any PRs.
