### PR TITLE
Remove ContentBlock::from_embed_code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.0.0
+
+* Remove rendering by way of Content Store (`ContactBlock.from_embed_code`). Blocks 
+  are no longer being published to Content Store. See [ADR 15: Remove dependence on base_path](https://github.com/alphagov/content-block-manager/blob/ea52adea1dcaeaede9b3530295abe08ae045c676/docs/architecture/decisions/0015-remove-dependence-on-base-path.md).
+  We've already removed the 2 known usages of this: Publisher and Smart Answers. 
+  See [PR 180](https://github.com/alphagov/govuk_content_block_tools/pull/180)
+
 ## 1.14.1
 
 * Update dependencies

--- a/lib/content_block_tools/content_block.rb
+++ b/lib/content_block_tools/content_block.rb
@@ -49,38 +49,6 @@ module ContentBlockTools
 
     attr_reader :content_id, :title, :embed_code
 
-    # Creates a ContentBlock instance from an embed code string by fetching
-    # the content item data from the Content Store API.
-    #
-    # @param embed_code [String] The embed code string to parse and fetch content for
-    #   @example
-    #     ContentBlock.from_embed_code("{{embed:content_block_pension:2b92cade-549c-4449-9796-e7a3957f3a86}}")
-    #
-    # @return [ContentBlock] A new ContentBlock instance populated with data from the Content Store
-    #
-    # @raise [ContentBlockTools::InvalidEmbedCodeError] if the embed code format is invalid
-    # @raise [GdsApi::HTTPErrorResponse] if the API request fails
-    #
-    # @example Create a ContentBlock from an embed code
-    #   embed_code = "{{embed:content_block_email:123e4567-e89b-12d3-a456-426614174000}}"
-    #   content_block = ContentBlock.from_embed_code(embed_code)
-    #   content_block.title #=> "Contact Email"
-    #   content_block.document_type #=> "email"
-    #
-    # @see ContentBlockReference.from_string
-    # @see GdsApi.content_store
-    def self.from_embed_code(embed_code)
-      reference = ContentBlockReference.from_string(embed_code)
-      api_response = GdsApi.content_store.content_item(reference.content_store_identifier)
-      new(
-        content_id: api_response["content_id"],
-        title: api_response["title"],
-        document_type: api_response["document_type"],
-        details: api_response["details"],
-        embed_code:,
-      )
-    end
-
     def initialize(content_id:, title:, document_type:, details:, embed_code:)
       @content_id = content_id
       @title = title

--- a/lib/content_block_tools/content_block_reference.rb
+++ b/lib/content_block_tools/content_block_reference.rb
@@ -52,21 +52,6 @@ module ContentBlockTools
       !identifier.match?(UUID_REGEX)
     end
 
-    # Returns the content store path for this content block reference
-    #
-    # Constructs a path used to identify and retrieve the content block from the content store.
-    # The path follows the format `/content-blocks/{document_type}/{identifier}`.
-    #
-    # @example
-    #   reference = ContentBlockReference.new(document_type: "content_block_contact", identifier: "some-slug", embed_code: "...")
-    #   reference.content_store_identifier
-    #   #=> "/content-blocks/content_block_contact/some-slug"
-    #
-    # @return [String] the content store path for this content block
-    def content_store_identifier
-      "/content-blocks/#{document_type}/#{identifier}"
-    end
-
     class << self
       # Finds all content block references within a document, using `ContentBlockReference::EMBED_REGEX`
       # to scan through the document

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "1.14.1"
+  VERSION = "2.0.0"
 end

--- a/spec/content_block_tools/content_block_reference_spec.rb
+++ b/spec/content_block_tools/content_block_reference_spec.rb
@@ -43,18 +43,6 @@ RSpec.describe ContentBlockTools::ContentBlockReference do
     end
   end
 
-  describe "#content_store_identifier" do
-    it "returns the identifier" do
-      content_block = described_class.new(
-        document_type:,
-        identifier: "some-alias",
-        embed_code:,
-      )
-
-      expect(content_block.content_store_identifier).to eq("/content-blocks/content_block_pension/some-alias")
-    end
-  end
-
   describe ".find_all_in_document" do
     let(:result) { described_class.find_all_in_document(document) }
 

--- a/spec/content_block_tools/content_block_spec.rb
+++ b/spec/content_block_tools/content_block_spec.rb
@@ -22,51 +22,6 @@ RSpec.describe ContentBlockTools::ContentBlock do
     expect(content_block.details).to eq(details)
   end
 
-  describe "#from_embed_code" do
-    let(:embed_code) { "{{embed:content_block_pension:my-pension}}" }
-    let(:api_response) do
-      {
-        "content_id" => "my-pension",
-        "title" => "My Pension",
-        "details" => { "some" => "details" },
-        "document_type" => "content_block_pension",
-      }
-    end
-    let(:reference) do
-      double(ContentBlockTools::ContentBlockReference,
-             document_type: "content_block_pension",
-             identifier: "my-pension",
-             embed_code: embed_code)
-    end
-    let(:content_store_identifier) { "/content-blocks/content_block_pension/my-pension" }
-    let(:content_block) { double(ContentBlockTools::ContentBlock) }
-    let(:content_store) { double(GdsApi::ContentStore) }
-
-    before do
-      allow(GdsApi).to receive(:content_store).and_return(content_store)
-    end
-
-    it "returns a content block" do
-      expect(ContentBlockTools::ContentBlockReference).to receive(:from_string)
-                                                            .with(embed_code)
-                                                            .and_return(reference)
-
-      expect(reference).to receive(:content_store_identifier)
-                             .and_return(content_store_identifier)
-
-      expect(content_store).to receive(:content_item)
-                                 .with(content_store_identifier)
-                                 .and_return(api_response)
-
-      content_block = ContentBlockTools::ContentBlock.from_embed_code(embed_code)
-
-      expect(content_block.content_id).to eq(api_response["content_id"])
-      expect(content_block.title).to eq(api_response["title"])
-      expect(content_block.details).to eq(api_response["details"].deep_symbolize_keys)
-      expect(content_block.document_type).to eq("pension")
-    end
-  end
-
   describe ".details" do
     let(:details) do
       {


### PR DESCRIPTION
Jira [CR-37](https://gov-uk.atlassian.net/browse/CR-37)

The process of conforming to [RFC-192][rfc_192] brought it to our attention that we don't in fact currently have a valid use-case for publishing our blocks to the Content Store and therefore don't need to publish a base_path. See [ADR 15: Remove dependence on base_path][adr_15].

In this commit we remove the ContentBlock::from_embed_code method which fetches a block from the Content Store using its `base_path` in order to then render it into HTML.

We had 2 callers of this method:

1. **Publisher** was using this in `HtmlRenderer` before sending a document to for fact check. We've refactored that call site to:

  - obtain the block from Publishing API
  - build the renderable block with `ContentBlock.new`

    See [Publisher PR 3411][publisher_pr_3411]

2. **Smart Answers** was using a `ContentBlockDetector` to (potentially) retrieve blocks from Content Store. However, this was a hypothetical implementation as no smart answers currently use content blocks.

   See [Smart Answers PR 7735][smart_answers_pr_7735]

   In the future if Smart Answers needs to use content blocks we can reimplement something similar but using our own API see [ADR 13: Add API to Content Block Manager][adr_13]

[rfc_192]:
https://github.com/alphagov/govuk-rfcs/pull/192/

[adr_15]:
https://github.com/alphagov/content-block-manager/blob/ea52adea1dcaeaede9b3530295abe08ae045c676/docs/architecture/decisions/0015-remove-dependence-on-base-path.md

[publisher_pr_3411]:
https://github.com/alphagov/publisher/pull/3411

[smart_answers_pr_7735]:
https://github.com/alphagov/smart-answers/pull/7735

[adr_13]:
https://github.com/alphagov/content-block-manager/blob/72c24769c2accb023a4ac3ef45e632e71f2d4edd/docs/architecture/decisions/0013-add-an-api-for-content-block-manager.md




[CR-37]: https://gov-uk.atlassian.net/browse/CR-37?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ