### PR TITLE
Return empty wrapper if format can't be applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.0
+
+* Return empty content if format is not applicable. [#181](https://github.com/alphagov/govuk_content_block_tools/pull/181/)
+
 ## 2.0.0
 
 * Remove rendering by way of Content Store (`ContactBlock.from_embed_code`). Blocks 

--- a/app/components/content_block_tools/tax_component.rb
+++ b/app/components/content_block_tools/tax_component.rb
@@ -8,11 +8,10 @@ module ContentBlockTools
     def initialize(content_block:, _block_type: nil, _block_name: nil)
       @content_block = content_block
       validate_format!
-      validate_presence_of_income_tax_rates! if tax_table_format?
     end
 
     def render
-      return "" unless tax_table_format?
+      return "" unless tax_table_format? && able_to_format_as_table?
 
       Tax::TaxTableComponent.new(rates: income_tax_rates).render
     end
@@ -29,11 +28,8 @@ module ContentBlockTools
       raise InvalidFormatError, "Unknown format '#{format}' for tax"
     end
 
-    def validate_presence_of_income_tax_rates!
-      return if income_tax_rates&.any?
-
-      raise InvalidFormatError,
-            "Cannot render 'tax_table' format: missing income tax rates"
+    def able_to_format_as_table?
+      income_tax_rates&.present?
     end
 
     def tax_table_format?

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -6,3 +6,7 @@ Then("the rendered output should be {string}") do |expected_text|
   expect(@error).to be_nil, "Expected no error but got: #{@error&.message}"
   expect(@rendered).to include(expected_text)
 end
+
+Then("the rendered output should be an empty wrapper") do
+  expect(Nokogiri::HTML::DocumentFragment.parse(@rendered).css("div").text).to be_blank
+end

--- a/features/tax_rendering.feature
+++ b/features/tax_rendering.feature
@@ -19,7 +19,7 @@ Feature: Tax rendering
     When asked to render tax with embed code "{{embed:content_block_tax:income-tax#unknown_format}}"
     Then an InvalidFormatError should be raised with message "Unknown format 'unknown_format' for tax"
 
-  Scenario: Raise error when income tax data is missing
+  Scenario: Return an empty string when the block can't be rendered as a tax table
     Given a tax content block without income data
     When asked to render tax with embed code "{{embed:content_block_tax:other-tax#tax_table}}"
-    Then an InvalidFormatError should be raised with message "Cannot render 'tax_table' format: missing income tax rates"
+    Then the rendered output should be an empty wrapper

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end

--- a/spec/content_block_tools/components/content_block_tools/tax_component_spec.rb
+++ b/spec/content_block_tools/components/content_block_tools/tax_component_spec.rb
@@ -110,50 +110,41 @@ RSpec.describe ContentBlockTools::TaxComponent do
       end
     end
 
-    describe "data validation for tax_table" do
+    describe "when the tax object can't be formatted as a tax table" do
       let(:embed_code) { "{{embed:content_block_tax:income-tax#tax_table}}" }
-
       context "when things_taxed is missing" do
         let(:details) { { tax_type: "Tax" } }
 
-        it "raises InvalidFormatError with descriptive message" do
-          expect { component }.to raise_error(
-            ContentBlockTools::InvalidFormatError,
-            "Cannot render 'tax_table' format: missing income tax rates",
-          )
+        it "renders an empty string" do
+          rendered = component.render
+          expect(rendered).to eq("")
         end
       end
 
       context "when income is missing from things_taxed" do
         let(:details) { { tax_type: "Tax", things_taxed: {} } }
 
-        it "raises InvalidFormatError with descriptive message" do
-          expect { component }.to raise_error(
-            ContentBlockTools::InvalidFormatError,
-            "Cannot render 'tax_table' format: missing income tax rates",
-          )
+        it "renders an empty string" do
+          rendered = component.render
+          expect(rendered).to eq("")
         end
       end
 
       context "when rates is missing from income" do
         let(:details) { { tax_type: "Tax", things_taxed: { income: { title: "Income" } } } }
 
-        it "raises InvalidFormatError with descriptive message" do
-          expect { component }.to raise_error(
-            ContentBlockTools::InvalidFormatError,
-            "Cannot render 'tax_table' format: missing income tax rates",
-          )
+        it "renders an empty string" do
+          rendered = component.render
+          expect(rendered).to eq("")
         end
       end
 
       context "when rates is empty" do
         let(:details) { { tax_type: "Tax", things_taxed: { income: { rates: [] } } } }
 
-        it "raises InvalidFormatError with descriptive message" do
-          expect { component }.to raise_error(
-            ContentBlockTools::InvalidFormatError,
-            "Cannot render 'tax_table' format: missing income tax rates",
-          )
+        it "renders an empty string" do
+          rendered = component.render
+          expect(rendered).to eq("")
         end
       end
     end


### PR DESCRIPTION
Not all tax objects can be rendered using the the `tax_table` format. e.g. it does not make sense for a tax object which expresses a single VAT rate, e.g. with

```rb
details: {
  "things_taxed" => {
    "good" => {
      "title" => "goods",
      "type" => "Entity value",
      "rates" => [
        {
          "name" => "standard rate",
          "value" => "20%"
        }
      ]
    }
   }
 }

```

Rather than raising `ContentBlockTools::InvalidFormatError`, when the given tax block can't be rendered as a tax table, we now return an empty wrapper:

```html
<div
  class="content-block content-block--tax
  data-content-block="
  data-document-type="tax
  data-content-id="74f91420-7bd6-4d42-b197-5bdf9a185f6e
  data-embed-code="{{embed:content_block_tax:vat#tax_table}}"
  >
</div>
```

The caller can test to see whether it's received an empty `div` or not to determine whether the format was applicable. This is what we will do in Content Block Manager's `Edition::Show::FormatBlockComponent#render?`. See https://github.com/alphagov/content-block-manager/pull/661

### When the format CAN'T be applied

<img width="1827" height="3384" alt="dont_render_inapplicable_format" src="https://github.com/user-attachments/assets/a3a5bbf8-785b-4917-bfba-5a4494bdaf49" />


### When format CAN be applied

<img width="838" height="1634" alt="do_render_applicable_format" src="https://github.com/user-attachments/assets/d1a5dc99-6813-44b1-8ff5-53aee403afe6" />
