### PR TITLE
Return common failure message if unable to render tax table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1.0
+
+* Return standard failure message if format is not applicable, component doesn't 
+  exist or internal content is not found [#182](https://github.com/alphagov/govuk_content_block_tools/pull/182/)
+
 ## 2.0.0
 
 * Remove rendering by way of Content Store (`ContactBlock.from_embed_code`). Blocks 

--- a/app/components/content_block_tools/tax_component.rb
+++ b/app/components/content_block_tools/tax_component.rb
@@ -8,11 +8,10 @@ module ContentBlockTools
     def initialize(content_block:, _block_type: nil, _block_name: nil)
       @content_block = content_block
       validate_format!
-      validate_presence_of_income_tax_rates! if tax_table_format?
     end
 
     def render
-      return "" unless tax_table_format?
+      raise format_inapplicable_error unless tax_table_format? && able_to_format_as_table?
 
       Tax::TaxTableComponent.new(rates: income_tax_rates).render
     end
@@ -23,17 +22,18 @@ module ContentBlockTools
 
     delegate :format, :details, to: :content_block
 
+    def format_inapplicable_error
+      InvalidFormatError.new("Cannot render 'tax_table' format: missing income tax rates")
+    end
+
     def validate_format!
       return if SUPPORTED_FORMATS.include?(format)
 
       raise InvalidFormatError, "Unknown format '#{format}' for tax"
     end
 
-    def validate_presence_of_income_tax_rates!
-      return if income_tax_rates&.any?
-
-      raise InvalidFormatError,
-            "Cannot render 'tax_table' format: missing income tax rates"
+    def able_to_format_as_table?
+      income_tax_rates&.present?
     end
 
     def tax_table_format?

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -6,3 +6,13 @@ Then("the rendered output should be {string}") do |expected_text|
   expect(@error).to be_nil, "Expected no error but got: #{@error&.message}"
   expect(@rendered).to include(expected_text)
 end
+
+Then("I should see the rendering failure message") do
+  expect(@rendered).to have_tag(
+    "div",
+    text: rendering_failure_message(
+      title: @content_block.title,
+      embed_code: @content_block.embed_code,
+    ),
+  )
+end

--- a/features/step_definitions/time_period_steps.rb
+++ b/features/step_definitions/time_period_steps.rb
@@ -27,11 +27,6 @@ When("asked to render with embed code {string}") do |embed_code|
   end
 end
 
-Then("an InvalidFormatError should be raised with message {string}") do |expected_message|
-  expect(@error).to be_a(ContentBlockTools::InvalidFormatError)
-  expect(@error.message).to eq(expected_message)
-end
-
 Given("a time period content block exists") do
   @content_block = ContentBlockTools::ContentBlock.new(
     document_type: "content_block_time_period",

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,4 +1,5 @@
 require File.expand_path("../../spec/dummy/config/environment", __dir__)
+require File.expand_path("../../spec/helpers", __dir__)
 require "rspec-html-matchers"
 
 World(RSpecHtmlMatchers)

--- a/features/tax_rendering.feature
+++ b/features/tax_rendering.feature
@@ -14,12 +14,12 @@ Feature: Tax rendering
       | Higher rate        | £50,271 to £125,140 | 40% |
       | Additional rate    | over £125,140       | 45% |
 
-  Scenario: Raise error for invalid format
+  Scenario: Return a failure message for invalid format
     Given a tax content block with income tax rates
     When asked to render tax with embed code "{{embed:content_block_tax:income-tax#unknown_format}}"
-    Then an InvalidFormatError should be raised with message "Unknown format 'unknown_format' for tax"
+    Then I should see the rendering failure message
 
-  Scenario: Raise error when income tax data is missing
+  Scenario: Return a failure message when block can't be rendered as a tax table
     Given a tax content block without income data
     When asked to render tax with embed code "{{embed:content_block_tax:other-tax#tax_table}}"
-    Then an InvalidFormatError should be raised with message "Cannot render 'tax_table' format: missing income tax rates"
+    Then I should see the rendering failure message

--- a/features/time_period_rendering.feature
+++ b/features/time_period_rendering.feature
@@ -40,6 +40,6 @@ Feature: Time period rendering
     When asked to render with embed code "{{embed:content_block_time_period:tax-year#years_short}}"
     Then the rendered output should be "2025-26"
 
-  Scenario: Raise error for invalid format
+  Scenario: Render failure message for invalid format
     When asked to render with embed code "{{embed:content_block_time_period:tax-year#unknown_format}}"
-    Then an InvalidFormatError should be raised with message "Unknown format 'unknown_format' for time_period"
+    Then I should see the rendering failure message

--- a/lib/content_block_tools/renderer.rb
+++ b/lib/content_block_tools/renderer.rb
@@ -39,6 +39,10 @@ module ContentBlockTools
 
     attr_reader :content_block
 
+    def failure_message
+      "Unable to render block '#{content_block.title}' #{content_block.embed_code}"
+    end
+
     def base_tag
       rendering_block? ? :div : :span
     end
@@ -46,7 +50,7 @@ module ContentBlockTools
     def content
       internal_content_path.present? ? field_or_block_content : component.new(content_block:).render
     rescue UnknownComponentError
-      content_block.title
+      failure_message
     end
 
     def field_or_block_content
@@ -59,7 +63,7 @@ module ContentBlockTools
         render_hash_content(field_content)
       else
         log_content_not_found
-        content_block.embed_code
+        failure_message
       end
     end
 

--- a/lib/content_block_tools/renderer.rb
+++ b/lib/content_block_tools/renderer.rb
@@ -49,7 +49,7 @@ module ContentBlockTools
 
     def content
       internal_content_path.present? ? field_or_block_content : component.new(content_block:).render
-    rescue UnknownComponentError
+    rescue UnknownComponentError, InvalidFormatError
       failure_message
     end
 

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end

--- a/spec/content_block_tools/components/content_block_tools/tax_component_spec.rb
+++ b/spec/content_block_tools/components/content_block_tools/tax_component_spec.rb
@@ -110,14 +110,13 @@ RSpec.describe ContentBlockTools::TaxComponent do
       end
     end
 
-    describe "data validation for tax_table" do
+    describe "when the tax object can't be formatted as a tax table" do
       let(:embed_code) { "{{embed:content_block_tax:income-tax#tax_table}}" }
-
       context "when things_taxed is missing" do
         let(:details) { { tax_type: "Tax" } }
 
         it "raises InvalidFormatError with descriptive message" do
-          expect { component }.to raise_error(
+          expect { component.render }.to raise_error(
             ContentBlockTools::InvalidFormatError,
             "Cannot render 'tax_table' format: missing income tax rates",
           )
@@ -128,7 +127,7 @@ RSpec.describe ContentBlockTools::TaxComponent do
         let(:details) { { tax_type: "Tax", things_taxed: {} } }
 
         it "raises InvalidFormatError with descriptive message" do
-          expect { component }.to raise_error(
+          expect { component.render }.to raise_error(
             ContentBlockTools::InvalidFormatError,
             "Cannot render 'tax_table' format: missing income tax rates",
           )
@@ -139,7 +138,7 @@ RSpec.describe ContentBlockTools::TaxComponent do
         let(:details) { { tax_type: "Tax", things_taxed: { income: { title: "Income" } } } }
 
         it "raises InvalidFormatError with descriptive message" do
-          expect { component }.to raise_error(
+          expect { component.render }.to raise_error(
             ContentBlockTools::InvalidFormatError,
             "Cannot render 'tax_table' format: missing income tax rates",
           )
@@ -150,7 +149,7 @@ RSpec.describe ContentBlockTools::TaxComponent do
         let(:details) { { tax_type: "Tax", things_taxed: { income: { rates: [] } } } }
 
         it "raises InvalidFormatError with descriptive message" do
-          expect { component }.to raise_error(
+          expect { component.render }.to raise_error(
             ContentBlockTools::InvalidFormatError,
             "Cannot render 'tax_table' format: missing income tax rates",
           )

--- a/spec/content_block_tools/content_block_spec.rb
+++ b/spec/content_block_tools/content_block_spec.rb
@@ -140,10 +140,17 @@ RSpec.describe ContentBlockTools::ContentBlock do
       context "embed code references a non-existent field" do
         let(:embed_code) { "{{embed:content_block_contact:contact/email_addresses/something/bleh}}" }
 
-        it "uses the presenter to render the field" do
+        it "uses the presenter to render the field with failure message" do
           expect(ContentBlockTools.logger).to receive(:warn).with("Content not found for content block #{content_id} and fields [:email_addresses, :something, :bleh]")
 
-          expect(content_block.render).to have_tag("span", text: embed_code, with: expected_wrapper_attributes)
+          expect(content_block.render).to have_tag(
+            "span",
+            text: rendering_failure_message(
+              title: content_block.title,
+              embed_code: content_block.embed_code,
+            ),
+            with: expected_wrapper_attributes,
+          )
         end
       end
     end
@@ -310,8 +317,15 @@ RSpec.describe ContentBlockTools::ContentBlock do
       context "embed code does not include any field or block references" do
         let(:embed_code) { "{{embed:content_block_contact:pension}}" }
 
-        it "returns the content block's title" do
-          expect(content_block.render).to have_tag("div", text: content_block.title, with: expected_wrapper_attributes)
+        it "returns the failure message" do
+          expect(content_block.render).to have_tag(
+            "div",
+            text: rendering_failure_message(
+              title: content_block.title,
+              embed_code: content_block.embed_code,
+            ),
+            with: expected_wrapper_attributes,
+          )
         end
       end
 

--- a/spec/content_block_tools/renderer_spec.rb
+++ b/spec/content_block_tools/renderer_spec.rb
@@ -65,6 +65,23 @@ RSpec.describe ContentBlockTools::Renderer do
       end
     end
 
+    context "when the component raises an InvalidFormatError" do
+      before do
+        allow_any_instance_of(ContentBlockTools::TimePeriodComponent).to receive(:render)
+          .and_raise(ContentBlockTools::InvalidFormatError)
+      end
+
+      it "displays failure message" do
+        expect(rendered).to have_tag(
+          "div",
+          text: rendering_failure_message(
+            title: content_block.title,
+            embed_code: content_block.embed_code,
+          ),
+        )
+      end
+    end
+
     context "when rendering a string field" do
       let(:embed_code) { "{{embed:content_block_contact:#{content_id}/email_addresses/main/email_address}}" }
 

--- a/spec/content_block_tools/renderer_spec.rb
+++ b/spec/content_block_tools/renderer_spec.rb
@@ -54,8 +54,14 @@ RSpec.describe ContentBlockTools::Renderer do
         )
       end
 
-      it "falls back to displaying the title" do
-        expect(rendered).to have_tag("div", seen: title)
+      it "displays failure message" do
+        expect(rendered).to have_tag(
+          "div",
+          text: rendering_failure_message(
+            title: content_block.title,
+            embed_code: content_block.embed_code,
+          ),
+        )
       end
     end
 
@@ -164,8 +170,14 @@ RSpec.describe ContentBlockTools::Renderer do
         )
       end
 
-      it "returns the embed code" do
-        expect(rendered).to include(embed_code)
+      it "displays failure message" do
+        expect(rendered).to have_tag(
+          "span",
+          text: rendering_failure_message(
+            title: content_block.title,
+            embed_code: content_block.embed_code,
+          ),
+        )
       end
     end
   end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -1,0 +1,3 @@
+def rendering_failure_message(title:, embed_code:)
+  "Unable to render block '#{title}' #{embed_code}"
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "helpers"
 require "simplecov"
 SimpleCov.start do
   minimum_coverage 100


### PR DESCRIPTION
In this PR we:

1. introduce a common failure message when we're unable to render a block
2. return the common failure message when we're unable to apply the requested format to a particular instance of a block

Previously, when rendering failed, we sometimes returned the block's embed code and sometimes returned the block's title.

Now we use a standard rendering failure message in the form:

```
Unable to render block '<title>' <embed code>
```

e.g.

```
Unable to render block 'VAT' {{embed:content_block_tax:vat#table_table}}
```

### Format NOT applicable

<img width="1109" height="1254" alt="format_not_applicable_std_failure_msg" src="https://github.com/user-attachments/assets/9cc99aa6-4c60-4ad0-a555-0c517c1e430c" />


### Format applicable

<img width="1139" height="1708" alt="format_applicable" src="https://github.com/user-attachments/assets/0bfc7354-a9a2-426a-97c4-82089bd588fa" />
